### PR TITLE
AP-35 | Sukreet, Charles, Ramesh | Adding provider filter from query string in list & calendar page

### DIFF
--- a/src/controllers/manage/calendar/appointmentsCalendarViewController.js
+++ b/src/controllers/manage/calendar/appointmentsCalendarViewController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .controller('AppointmentsCalendarViewController', ['$scope', '$state', '$translate', 'spinner', 'appointmentsService', 'appointmentsFilter', '$rootScope', '$interval', 'appService',
-        function ($scope, $state, $translate, spinner, appointmentsService, appointmentsFilter, $rootScope, $interval, appService) {
+    .controller('AppointmentsCalendarViewController', ['$scope', '$state', '$translate', 'spinner', 'appointmentsService', 'appointmentsFilter', '$rootScope', '$interval', 'appService', 'appointmentCommonService',
+        function ($scope, $state, $translate, spinner, appointmentsService, appointmentsFilter, $rootScope, $interval, appService, appointmentCommonService) {
             var autoRefreshIntervalInSeconds = parseInt(appService.getAppDescriptor().getConfigValue('autoRefreshIntervalInSeconds'));
             var enableAutoRefresh = !isNaN(autoRefreshIntervalInSeconds);
             var autoRefreshStatus = true;
@@ -21,6 +21,7 @@ angular.module('bahmni.appointments')
                 var weekStartDay = appService.getAppDescriptor().getConfigValue('startOfWeek')
                     || Bahmni.Appointments.Constants.defaultWeekStartDayName;
                 $scope.weekStart = Bahmni.Appointments.Constants.weekDays[weekStartDay];
+                appointmentCommonService.addProviderToFilterFromQueryString();
             };
 
             var createProviderEventForAppointment = function (provider, appointment, eventList) {

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -44,6 +44,7 @@ angular.module('bahmni.appointments')
                 $scope.searchedPatient = $stateParams.isSearchEnabled && $stateParams.patient;
                 $scope.startDate = $stateParams.viewDate || moment().startOf('day').toDate();
                 $scope.isFilterOpen = $stateParams.isFilterOpen;
+                appointmentCommonService.addProviderToFilterFromQueryString();
             };
 
             var setAppointments = function (params) {

--- a/src/services/appointmentCommonService.js
+++ b/src/services/appointmentCommonService.js
@@ -1,9 +1,8 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .service('appointmentCommonService', ['$rootScope', 'ngDialog', '$state', '$translate', 'appointmentsService',
-        'confirmBox', 'checkinPopUp', 'appService', 'messagingService',
-        function ($rootScope, ngDialog, $state, $translate, appointmentsService, confirmBox, checkinPopUp, appService, messagingService) {
+    .service('appointmentCommonService', ['$state', '$location',
+        function ($state, $location) {
             this.isCurrentUserHavingPrivilege = function (privilege, currentUserPrivileges) {
                 return !_.isUndefined(_.find(currentUserPrivileges, function (userPrivilege) {
                     return userPrivilege.name === privilege;
@@ -24,4 +23,19 @@ angular.module('bahmni.appointments')
                     ? true : this.isCurrentUserHavingPrivilege(Bahmni.Appointments.Constants.privilegeOwnAppointments, currentUserPrivileges)
                         ? isOwnPrivilegedUserAllowedToPerformEdit(appointmentProviders, currentProviderUuId) : false;
             };
+
+            this.addProviderToFilterFromQueryString = function () {
+                if ($location.search()["provider"]) {
+                    let fitlers = $state.params.filterParams;
+                    const provider = $location.search()["provider"];
+                    
+                    if (!Array.isArray(fitlers.providerUuids))  {
+                        fitlers.providerUuids = [];
+                    }
+
+                    if(fitlers.providerUuids.indexOf(provider) < 0) {
+                        fitlers.providerUuids.push(provider);
+                    }
+                }
+            }
         }]);

--- a/test/services/appointmentCommonService.spec.js
+++ b/test/services/appointmentCommonService.spec.js
@@ -2,10 +2,17 @@
 
 describe('AppointmentCommonService', function () {
     var appointmentCommonService;
-
+    const mockState = { params: { filterParams: {} } };
+    const mockLocation = jasmine.createSpyObj('$location', ['search']);
+    
     beforeEach(function () {
         module('bahmni.appointments');
     });
+
+    beforeEach(module(function ($provide) {
+        $provide.value('$location', mockLocation);
+        $provide.value('$state', mockState);
+    }));
 
     beforeEach(inject(['appointmentCommonService', function (appointmentCommonServiceInjected) {
         appointmentCommonService = appointmentCommonServiceInjected;
@@ -82,5 +89,53 @@ describe('AppointmentCommonService', function () {
         });
     });
 
+    describe('addProviderToFilterFromQueryString', function() {
+        it('should assign provider uuid to state params filter', function(){
+            mockLocation.search.and.returnValue({'provider': 'test-provider-id'})
+            
+            appointmentCommonService.addProviderToFilterFromQueryString();
+            
+            expect(mockState.params.filterParams.providerUuids[0]).toBe('test-provider-id');
+        });
+
+        it('should not assign provider uuid to state params filter when querystring does not have', function(){
+            mockState.params.filterParams.providerUuids = [];
+            mockLocation.search.and.returnValue({});
+
+            appointmentCommonService.addProviderToFilterFromQueryString();
+
+            expect(mockState.params.filterParams.providerUuids.length).toBe(0);
+        });
+
+        it('should adds provider uuid to existing state params filter', function(){
+            mockState.params.filterParams.providerUuids = ['existing-provider'];
+            mockLocation.search.and.returnValue({'provider': 'test-provider-id'})
+            
+            appointmentCommonService.addProviderToFilterFromQueryString();
+            
+            expect(mockState.params.filterParams.providerUuids[0]).toBe('existing-provider');
+            expect(mockState.params.filterParams.providerUuids[1]).toBe('test-provider-id');
+        });
+
+        it('should not add provider uuid to filter if already exists', function(){
+            mockState.params.filterParams.providerUuids = ['existing-provider'];
+            mockLocation.search.and.returnValue({'provider': 'existing-provider'})
+            
+            appointmentCommonService.addProviderToFilterFromQueryString();
+            
+            expect(mockState.params.filterParams.providerUuids.length).toBe(1);
+            expect(mockState.params.filterParams.providerUuids[0]).toBe('existing-provider');
+        });
+
+        it('should initialize providerUuids list', function(){
+            mockState.params.filterParams.providerUuids = undefined;
+            mockLocation.search.and.returnValue({'provider': 'existing-provider'})
+            
+            appointmentCommonService.addProviderToFilterFromQueryString();
+            
+            expect(mockState.params.filterParams.providerUuids.length).toBe(1);
+            expect(mockState.params.filterParams.providerUuids[0]).toBe('existing-provider');
+        });
+    });
 });
 


### PR DESCRIPTION
This PR enables list & calendar view page to add provider filter based on query string.
We are using existing filter options & just adding the provider uuid to state params.