### PR TITLE
AP-82 - Timezone support for service definitions start and end times

### DIFF
--- a/src/models/appointmentService.js
+++ b/src/models/appointmentService.js
@@ -10,7 +10,11 @@ Bahmni.Appointments.AppointmentService = (function () {
         var dateUtil = Bahmni.Common.Util.DateUtil;
 
         var getTime = function (dateTime) {
-            return dateTime ? dateUtil.getDateTimeInSpecifiedFormat(dateTime, timeFormat) : undefined;
+            let now = new Date();
+            now.setHours(dateTime.getHours());
+            now.setMinutes(dateTime.getMinutes());
+            now.setSeconds(dateTime.getSeconds());
+            return dateTime ? now.getUTCHours() + ':' + now.getUTCMinutes() + ':' + now.getUTCSeconds() : undefined;
         };
 
         var constructAvailabilityPerDay = function (result, availability) {

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -30,7 +30,7 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
 
     Service.createFromResponse = function (serviceDetails) {
         var getDateTime = function (time) {
-            return time ? new Date("January 01, 1970 " + time) : undefined;
+            return time ? new Date(time) : undefined;
         };
 
         var parseAvailability = function (avbsByDay) {

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -30,7 +30,15 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
 
     Service.createFromResponse = function (serviceDetails) {
         var getDateTime = function (time) {
-            return time ? new Date(time) : undefined;
+            if (!time) {
+                return undefined;
+            }
+            let date = new Date();
+            date.setHours(time.split(':')[0]);
+            date.setMinutes(time.split(':')[1]);
+            date.setSeconds(time.split(':')[2]);
+            date.setMilliseconds(0);
+            return date;
         };
 
         var parseAvailability = function (avbsByDay) {


### PR DESCRIPTION
**Ticket:** [AP-82](https://bahmni.atlassian.net/browse/AP-82)
**Description:** Reviewed services saving / loading to cope with timezones
- When posting appointment service data to server. Convert times to UTC.
- After loading an appointment service from server, convert times directly to date, they already include date and timezone info. No need to use "January 01, 1970". Also, using always January 1 could cause issues with daylight saving times.