### PR TITLE
AP-84 - Added table headers for AGE, GENDER, IDENTIFIERS

### DIFF
--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -35,6 +35,7 @@ angular.module('bahmni.appointments')
                 {heading: 'APPOINTMENT_PATIENT_AGE', sortInfo: 'patient.age', class: true, enable: true},
                 {heading: 'APPOINTMENT_PATIENT_GENDER', sortInfo: 'patient.gender', class: true, enable: true},
                 {heading: 'APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER', class: true, enable: true},
+
                 {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},
                 {heading: 'APPOINTMENT_START_TIME_KEY', sortInfo: 'startDateTime', enable: true},
                 {heading: 'APPOINTMENT_END_TIME_KEY', sortInfo: 'endDateTime', enable: true},

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -32,6 +32,9 @@ angular.module('bahmni.appointments')
             });
             $scope.tableInfo = [{heading: 'APPOINTMENT_PATIENT_ID', sortInfo: 'patient.identifier', enable: true},
                 {heading: 'APPOINTMENT_PATIENT_NAME', sortInfo: 'patient.name', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_AGE', sortInfo: 'patient.age', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_GENDER', sortInfo: 'patient.gender', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER', class: true, enable: true},
                 {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},
                 {heading: 'APPOINTMENT_START_TIME_KEY', sortInfo: 'startDateTime', enable: true},
                 {heading: 'APPOINTMENT_END_TIME_KEY', sortInfo: 'endDateTime', enable: true},

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -35,7 +35,6 @@ angular.module('bahmni.appointments')
                 {heading: 'APPOINTMENT_PATIENT_AGE', sortInfo: 'patient.age', class: true, enable: true},
                 {heading: 'APPOINTMENT_PATIENT_GENDER', sortInfo: 'patient.gender', class: true, enable: true},
                 {heading: 'APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER', class: true, enable: true},
-
                 {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},
                 {heading: 'APPOINTMENT_START_TIME_KEY', sortInfo: 'startDateTime', enable: true},
                 {heading: 'APPOINTMENT_END_TIME_KEY', sortInfo: 'endDateTime', enable: true},


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-84

The supported fields correspond to:
'APPOINTMENT_PATIENT_ID'; 'APPOINTMENT_DATE'; 'APPOINTMENT_START_TIME_KEY'; 'APPOINTMENT_END_TIME_KEY'; 'APPOINTMENT_PROVIDER'; 'APPOINTMENT_SERVICE_SPECIALITY_KEY';
'APPOINTMENT_SERVICE'; 'APPOINTMENT_SERVICE_TYPE_FULL'; 'APPOINTMENT_STATUS'; 'APPOINTMENT_WALK_IN'; 'APPOINTMENT_SERVICE_LOCATION_KEY';
'APPOINTMENT_ADDITIONAL_INFO'; 'APPOINTMENT_CREATE_NOTES'

Our suggestion is to add
Patient Age
Patient Gender
Patient Identifiers (other than patient identifier)

To accomplish this, we added table headers for APPOINTMENT_PATIENT_AGE, APPOINTMENT_PATIENT_GENDER and APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER