### PR TITLE
BAH-2019 | Update Appointments URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm run test-react-watch
 * Create a folder called 'appointments' under '/var/www'.
 * Add an alias in httpd ssl.conf, like below:
   ```
-  Alias /appointments-v2 /var/www/appointments
+  Alias /appointments /var/www/appointments
   ```
 
 # Project Structure

--- a/config/ng-config.json
+++ b/config/ng-config.json
@@ -143,7 +143,7 @@
         "CANCELLED": "CANCELLED",
         "AWAITING": "AWAITING"
       },
-      "appointmentsV2Url" : "/appointments-v2/#/home/manage/appointments"
+      "appointmentsV2Url" : "/appointments/#/home/manage/appointments"
     }
   }
 }

--- a/package/resources/appointments_ssl.conf
+++ b/package/resources/appointments_ssl.conf
@@ -1,2 +1,2 @@
 #For Appointments Frontend
-Alias /appointments-v2 /var/www/appointments
+Alias /appointments /var/www/appointments


### PR DESCRIPTION
SInce older version of appointments from bahmniapps is deprecated and is removed, setting the appointments URL as just `appointments`

JIRA: https://bahmni.atlassian.net/browse/BAH-2019

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)