### PR TITLE
AP-84-V2 - Added table headers for APPOINTMENT_PATIENT_AGE, APPOINTME…

### DIFF
--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -32,6 +32,9 @@ angular.module('bahmni.appointments')
             });
             $scope.tableInfo = [{heading: 'APPOINTMENT_PATIENT_ID', sortInfo: 'patient.identifier', enable: true},
                 {heading: 'APPOINTMENT_PATIENT_NAME', sortInfo: 'patient.name', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_AGE', sortInfo: 'patient.age', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_GENDER', sortInfo: 'patient.gender', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER', class: true, enable: true},
                 {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},
                 {heading: 'APPOINTMENT_START_TIME_KEY', sortInfo: 'startDateTime', enable: true},
                 {heading: 'APPOINTMENT_END_TIME_KEY', sortInfo: 'endDateTime', enable: true},

--- a/test/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/test/controllers/manage/list/appointmentsListViewController.spec.js
@@ -709,8 +709,11 @@ describe('AppointmentsListViewController', function () {
 
         it("should have table info", function () {
             var tableInfo = [{heading: 'APPOINTMENT_PATIENT_ID', sortInfo: 'patient.identifier', enable: true},
-                {heading: 'APPOINTMENT_PATIENT_NAME', sortInfo: 'patient.name', class: true, enable: true},
-                {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},
+                {heading: 'APPOINTMENT_PATIENT_NAME', sortInfo: 'patient.name', class: true, enable: true},   
+                {heading: 'APPOINTMENT_PATIENT_AGE', sortInfo: 'patient.age', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_GENDER', sortInfo: 'patient.gender', class: true, enable: true},
+                {heading: 'APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER', class: true, enable: true},
+                {heading: 'APPOINTMENT_DATE', sortInfo: 'date', enable: true},           
                 {heading: 'APPOINTMENT_START_TIME_KEY', sortInfo: 'startDateTime', enable: true},
                 {heading: 'APPOINTMENT_END_TIME_KEY', sortInfo: 'endDateTime', enable: true},
                 {heading: 'APPOINTMENT_PROVIDER', sortInfo: 'provider.name', class: true, enable: true},


### PR DESCRIPTION
Issue: https://bahmni.atlassian.net/browse/AP-84

The supported fields correspond to:
'APPOINTMENT_PATIENT_ID'; 'APPOINTMENT_DATE'; 'APPOINTMENT_START_TIME_KEY'; 'APPOINTMENT_END_TIME_KEY'; 'APPOINTMENT_PROVIDER'; 'APPOINTMENT_SERVICE_SPECIALITY_KEY';
'APPOINTMENT_SERVICE'; 'APPOINTMENT_SERVICE_TYPE_FULL'; 'APPOINTMENT_STATUS'; 'APPOINTMENT_WALK_IN'; 'APPOINTMENT_SERVICE_LOCATION_KEY';
'APPOINTMENT_ADDITIONAL_INFO'; 'APPOINTMENT_CREATE_NOTES'

Our suggestion is to add
Patient Age
Patient Gender
Patient Identifiers (other than patient identifier)

To accomplish this, we added table headers for APPOINTMENT_PATIENT_AGE, APPOINTMENT_PATIENT_GENDER and APPOINTMENT_PATIENT_AUXILIARY_IDENTIFIER

(Note this PR was summited once again to bypass an authentication problem when signing the CLA)
Original PR: https://github.com/Bahmni/openmrs-module-appointments-frontend/pull/202