### PR TITLE
Sowmya | BAH-3087 | Makes success notification message duration configurable and sets default duration to 5 seconds

### DIFF
--- a/ui/react-components/components/Notifications/Notifications.jsx
+++ b/ui/react-components/components/Notifications/Notifications.jsx
@@ -4,7 +4,7 @@ import {alertContainer} from "./popup.module.scss"
 import { InlineNotification } from "carbon-components-react";
 
 const Notifications = props => {
-    const {showMessage = false, title, onClose} = props
+    const {showMessage = false, title, onClose, messageDuration=5000} = props
     const ref = useRef(null)
     useEffect(()=>{
         if(showMessage){
@@ -13,7 +13,7 @@ const Notifications = props => {
             }
             ref.current = setTimeout(() => {
                 onClose();
-            }, 1500);
+            }, messageDuration);
         }
     },[showMessage])
 


### PR DESCRIPTION
This updates the success notification message duration on appointment creation and appointment edit to 5 seconds
Link to JIRA card- https://bahmni.atlassian.net/browse/BAH-3087