### PR TITLE
BAH-3154 | Add. httpd:2.4.57-alpine As Docker Base Image

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM httpd:2.4-alpine
+FROM httpd:2.4.57-alpine
 COPY dist/. /usr/local/apache2/htdocs/appointments/


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

**Base Image Update**: The base image `httpd` has been upgraded from version `2.4-alpine` to version `2.4.57-alpine`. 