### PR TITLE
BAH-3484 | Fix. Date format to be shown as dd/mmm/yyyy

### DIFF
--- a/ui/react-components/components/AddAppointment/AddAppointment.test.jsx
+++ b/ui/react-components/components/AddAppointment/AddAppointment.test.jsx
@@ -168,8 +168,8 @@ describe('Add Appointment', () => {
         const dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(selectedDate.date().toFixed(0));
 
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(selectedDate.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(selectedDate.format('DD/MMM/YYYY'));
 
         fireEvent.click(getByText('Check and Save'));
 
@@ -413,8 +413,8 @@ describe('Add Appointment', () => {
             appointmentParams={appointmentParams}/>);
         expect(container.querySelectorAll('.rc-time-picker-input')[0].value).toBe(today.format('h:mm A').toLowerCase());
         expect(container.querySelectorAll('.rc-time-picker-input')[1].value).toBe(addTwoHoursFromNow.format('h:mm A').toLowerCase());
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(today.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(today.format('DD/MMM/YYYY'));
     });
 
     it('should populate the start date, start time and end time coming as prop for recurring appointment', function () {
@@ -432,9 +432,9 @@ describe('Add Appointment', () => {
         fireEvent.click(checkBoxService);
         expect(container.querySelectorAll('.rc-time-picker-input')[0].value).toBe(today.format('h:mm A').toLowerCase());
         expect(container.querySelectorAll('.rc-time-picker-input')[1].value).toBe(addTwoHoursFromNow.format('h:mm A').toLowerCase());
-        const dateInputField = getAllByPlaceholderText('mm/dd/yyyy')[0];
+        const dateInputField = getAllByPlaceholderText('dd/mmm/yyyy')[0];
 
-        expect(dateInputField.value).toBe(today.format('MM/DD/YYYY'));
+        expect(dateInputField.value).toBe(today.format('DD/MMM/YYYY'));
     });
 
     it('should not add second provider when maxAppointmentProvidersAllowed is 1', async () => {
@@ -528,8 +528,8 @@ describe('Add Appointment', () => {
         const dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(selectedDate.date().toFixed(0));
 
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(selectedDate.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(selectedDate.format('DD/MMM/YYYY'));
 
     });
     it('should fetch patient details on load if patient is present in url params', () => {

--- a/ui/react-components/components/DatePicker/DateInput.jsx
+++ b/ui/react-components/components/DatePicker/DateInput.jsx
@@ -6,14 +6,14 @@ import{
     disable
 } from './DateInput.module.scss'
 import classNames from 'classnames';
-import {isValidUSDate} from '../../utils/DateUtil'
+import {isValidDate} from '../../utils/DateUtil'
 import PropTypes from "prop-types";
 import moment from "moment";
 import {isNil} from 'lodash'
 
 const DateInput = (props) =>{
     const validateDate= ({dateValue, minDate, maxDate}) =>{
-        const isDateFormatValid = isValidUSDate(dateValue) || dateValue==='';
+        const isDateFormatValid = isValidDate(dateValue) || dateValue==='';
         if(minDate && isDateFormatValid && dateValue!== ''){
           if( moment(dateValue, 'DD/MMM/YYYY').isBefore(moment(minDate).startOf('day'))) {
               return false;

--- a/ui/react-components/components/DatePicker/DateInput.jsx
+++ b/ui/react-components/components/DatePicker/DateInput.jsx
@@ -15,12 +15,12 @@ const DateInput = (props) =>{
     const validateDate= ({dateValue, minDate, maxDate}) =>{
         const isDateFormatValid = isValidUSDate(dateValue) || dateValue==='';
         if(minDate && isDateFormatValid && dateValue!== ''){
-          if( moment(dateValue, 'MM/DD/YYYY').isBefore(moment(minDate).startOf('day'))) {
+          if( moment(dateValue, 'DD/MMM/YYYY').isBefore(moment(minDate).startOf('day'))) {
               return false;
           }
         }
         if(maxDate && isDateFormatValid && dateValue!== ''){
-            if( moment(dateValue, 'MM/DD/YYYY').isAfter(moment(maxDate).startOf('day'))) {
+            if( moment(dateValue, 'DD/MMM/YYYY').isAfter(moment(maxDate).startOf('day'))) {
                 return false;
             }
         }
@@ -76,7 +76,7 @@ const DateInput = (props) =>{
 
     return(
         <div className={classNames(dateTextHolder)}>
-            <input placeholder="mm/dd/yyyy" onChange={(e) => setComponentValue(e.target.value)}
+            <input placeholder="dd/mmm/yyyy" onChange={(e) => setComponentValue(e.target.value)}
                    className={classNames(inputFieldStyles)}
                    onKeyDown={handleKeyDown}
                    ref={inputRef}

--- a/ui/react-components/components/DatePicker/DateInput.spec.jsx
+++ b/ui/react-components/components/DatePicker/DateInput.spec.jsx
@@ -9,41 +9,41 @@ describe('Date Input', ()=>{
     beforeEach(() => {
         onBlurSpy= jest.fn();
     });
-    it('should have placeholder mm/dd/yyy',()=>{
+    it('should have placeholder dd/mmm/yyy',()=>{
         const {container, getByPlaceholderText} = render(<DateInput onBlur={onBlurSpy}/>);
-        expect(getByPlaceholderText('mm/dd/yyyy')).not.toBeNull();
+        expect(getByPlaceholderText('dd/mmm/yyyy')).not.toBeNull();
     })
 
     it('should have a x symbol to clear',()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const {container, getByPlaceholderText, getByText} = render(<DateInput value={today} onBlur={onBlurSpy}/>);
         const closeButton = getByText('x');
-        const inputValue = getByPlaceholderText('mm/dd/yyyy');
+        const inputValue = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputValue.value).toBe(today);
         fireEvent.click(closeButton);
         expect(inputValue.value).toBe('');
         expect(onBlurSpy).toHaveBeenCalledWith('')
     })
 
-    it('should accept date value only in mm/dd/yyyy or mm-dd-yyyy format', ()=>{
-        const today = moment().format('MM, DD YYYY');
+    it('should accept date value only in dd/mmm/yyyy or mm-dd-yyyy format', ()=>{
+        const today = moment().format('DD, MMM YYYY');
         const {container, getByPlaceholderText, getByText} = render(<DateInput value={today} onBlur={onBlurSpy}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        const todayInUSDateFormat= moment().format('MM/DD/YYYY');
+        const todayInUSDateFormat= moment().format('DD/MMMM/YYYY');
         fireEvent.change(inputField, {target:{value:todayInUSDateFormat}})
         expect(inputField.value).toBe(todayInUSDateFormat);
-        const todayInUSDateFormatWithDash= moment().format('MM-DD-YYYY');
+        const todayInUSDateFormatWithDash= moment().format('DD-MMM-YYYY');
         fireEvent.change(inputField, {target:{value:todayInUSDateFormatWithDash}})
         expect(inputField.value).toBe(todayInUSDateFormatWithDash);
     })
 
     it('should not call onBlur with new date value if new date is invalid', ()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const invalidDate = 'abc';
         const {container, getByPlaceholderText, getByText} = render(<DateInput value={today} onBlur={onBlurSpy}/>);
         const closeButton = getByText('x');
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe(today);
         fireEvent.change(inputField, {target:{value:invalidDate}});
         fireEvent.blur(inputField);
@@ -52,11 +52,11 @@ describe('Date Input', ()=>{
     })
 
     it('should call onBlur with new date value if new date is valid', ()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}/>);
         const closeButton = getByText('x');
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
         fireEvent.change(inputField, {target:{value:validDate}});
         fireEvent.blur(inputField);
@@ -64,29 +64,29 @@ describe('Date Input', ()=>{
     })
 
     it('should not allow a date below the given min date value', ()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const minDate= moment().toDate();
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                minDate={minDate}/>);
         const dateBeforeToday = moment().subtract(2, "days");
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        fireEvent.change(inputField, {target:{value:dateBeforeToday.format('MM/DD/YYYY')}});
+        fireEvent.change(inputField, {target:{value:dateBeforeToday.format('DD/MMM/YYYY')}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe('');
     })
 
     it('should  allow a date after the given min date value', ()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const minDate= moment().toDate();
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                minDate={minDate}/>);
         const dateAfterToday = moment().add(2, "days");
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        const fomatedDateAfterToday = dateAfterToday.format('MM/DD/YYYY');
+        const fomatedDateAfterToday = dateAfterToday.format('DD/MMM/YYYY');
         fireEvent.change(inputField, {target:{value: fomatedDateAfterToday}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe(fomatedDateAfterToday);
@@ -98,9 +98,9 @@ describe('Date Input', ()=>{
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                minDate={minDate}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        const formatedMinDate = today.format('MM/DD/YYYY');
+        const formatedMinDate = today.format('DD/MMM/YYYY');
         fireEvent.change(inputField, {target:{value: formatedMinDate}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe(formatedMinDate);
@@ -108,29 +108,29 @@ describe('Date Input', ()=>{
 
 
     it('should not allow a date above the given max date value', ()=>{
-        const oneDayAfterToday = moment().add(1, 'days').format('MM/DD/YYYY');
+        const oneDayAfterToday = moment().add(1, 'days').format('DD/MMM/YYYY');
         const maxDate= moment().add(1, 'days').toDate();
         const validDate = oneDayAfterToday;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                maxDate={maxDate}/>);
         const twoDayAfterToday = moment().add(2, "days");
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        fireEvent.change(inputField, {target:{value:twoDayAfterToday.format('MM/DD/YYYY')}});
+        fireEvent.change(inputField, {target:{value:twoDayAfterToday.format('DD/MMM/YYYY')}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe('');
     })
 
     it('should  allow a date before the given max date value', ()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const maxDate= moment().add(2, 'days').toDate();
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                maxDate={maxDate}/>);
         const dateAfterToday = moment().add(1, "days");
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        const fomatedDateAfterToday = dateAfterToday.format('MM/DD/YYYY');
+        const fomatedDateAfterToday = dateAfterToday.format('DD/MMM/YYYY');
         fireEvent.change(inputField, {target:{value: fomatedDateAfterToday}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe(fomatedDateAfterToday);
@@ -142,9 +142,9 @@ describe('Date Input', ()=>{
         const validDate = today;
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                maxDate={maxDate}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
-        const formatedMinDate = today.format('MM/DD/YYYY');
+        const formatedMinDate = today.format('DD/MMM/YYYY');
         fireEvent.change(inputField, {target:{value: formatedMinDate}});
         fireEvent.blur(inputField);
         expect(inputField.value).toBe(formatedMinDate);
@@ -153,15 +153,15 @@ describe('Date Input', ()=>{
     it('should not allow the value to be editable if disabled is true',()=>{
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                isDisabled={true}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.disabled).toBe(true);
     })
 
     it('should not allow the value to be cleared if disabled is true',()=>{
-        const today = moment().format('MM/DD/YYYY');
+        const today = moment().format('DD/MMM/YYYY');
         const {container, getByPlaceholderText, getByText} = render(<DateInput value={today} onBlur={onBlurSpy}
                                                                                isDisabled={true}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.disabled).toBe(true);
         const closeButton = getByText('x');
         fireEvent.click(closeButton);
@@ -172,19 +172,19 @@ describe('Date Input', ()=>{
     it('should  allow the value to be editable if disabled is false',()=>{
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}
                                                                                isDisabled={false}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.disabled).toBe(false);
     })
 
     it('should  allow the value to be editable if disabled is not passed',()=>{
         const {container, getByPlaceholderText, getByText} = render(<DateInput value='' onBlur={onBlurSpy}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.disabled).toBe(false);
     })
 
     it('should set the date to empty string when invalid date is entered',()=>{
         const {container, getByPlaceholderText, getByText} = render(<DateInput onBlur={onBlurSpy}/>);
-        const inputField = getByPlaceholderText('mm/dd/yyyy');
+        const inputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(inputField.value).toBe('');
         fireEvent.change(inputField, {target:{value:'322'}});
         fireEvent.blur(inputField);

--- a/ui/react-components/components/DatePicker/DatePicker.jsx
+++ b/ui/react-components/components/DatePicker/DatePicker.jsx
@@ -19,7 +19,7 @@ if (locale) {
 }
 
 const dateToMomentDate = (date) => date === '' || date === null || date === undefined ? date
-    : moment(date, 'MM/DD/YYYY');
+    : moment(date, 'DD/MMM/YYYY');
 const AppointmentDatePicker = (props) => {
     const {minDate, value, onChange, isDisabled, handleDateSelection} = props;
     let calendarStyles = [appointmentDatePicker];
@@ -34,7 +34,7 @@ const AppointmentDatePicker = (props) => {
         onChange(valueEntered);
     };
 
-    const dateInputValue = isDisabled ? '' : (value && value !== '' ? value.format('MM/DD/YYYY') : value);
+    const dateInputValue = isDisabled ? '' : (value && value !== '' ? value.format('DD/MMM/YYYY') : value);
 
     return (
         <div data-testid="datePicker" className={classNames(containerStyles)}>

--- a/ui/react-components/components/DatePicker/DatePicker.spec.jsx
+++ b/ui/react-components/components/DatePicker/DatePicker.spec.jsx
@@ -48,8 +48,8 @@ describe('DatePicker', () => {
         const {container, getByPlaceholderText} = render(<AppointmentDatePicker value={fiveDaysFromToday}/>);
         const dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(fiveDaysFromToday.date().toFixed(0));
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(fiveDaysFromToday.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(fiveDaysFromToday.format('DD/MMM/YYYY'));
     })
 
     it('should not allow entry of date before min date and should fallback to previously selected date',()=>{
@@ -59,15 +59,15 @@ describe('DatePicker', () => {
                                                                                 minDate={minDate}/>);
         let dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(fiveDaysFromToday.date().toFixed(0));
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(fiveDaysFromToday.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(fiveDaysFromToday.format('DD/MMM/YYYY'));
 
         fireEvent.change(dateInputField, {target:{value: minDate.subtract(1, 'days')
-                    .format('MM/DD/YYYY')}})
+                    .format('DD/MMM/YYYY')}})
         fireEvent.blur(dateInputField);
         dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(fiveDaysFromToday.date().toFixed(0));
-        expect(dateInputField.value).toBe(fiveDaysFromToday.format('MM/DD/YYYY'));
+        expect(dateInputField.value).toBe(fiveDaysFromToday.format('DD/MMM/YYYY'));
     })
 
     it('should update the calendar and the input field when new valid date is entered inside the input field',()=>{
@@ -79,15 +79,15 @@ describe('DatePicker', () => {
                                                                                 minDate={minDate}/>);
         let dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(fiveDaysFromToday.date().toFixed(0));
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(fiveDaysFromToday.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(fiveDaysFromToday.format('DD/MMM/YYYY'));
 
-        fireEvent.change(dateInputField, {target:{value: newSelectedDate.format('MM/DD/YYYY')}})
+        fireEvent.change(dateInputField, {target:{value: newSelectedDate.format('DD/MMM/YYYY')}})
         fireEvent.blur(dateInputField);
 
         dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(newSelectedDate.date().toFixed(0));
-        expect(dateInputField.value).toBe(newSelectedDate.format('MM/DD/YYYY'));
+        expect(dateInputField.value).toBe(newSelectedDate.format('DD/MMM/YYYY'));
     })
 
     it('should update the calendar and the input field when new valid date is selected from the calendar view', async ()=>{
@@ -97,8 +97,8 @@ describe('DatePicker', () => {
         let dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(today.date().toFixed(0));
 
-        let dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(today.format('MM/DD/YYYY'));
+        let dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(today.format('DD/MMM/YYYY'));
 
         const nextMonth =today.add(1, 'months');
         const nextButton = container.querySelector('.react-datepicker__navigation--next');
@@ -111,8 +111,8 @@ describe('DatePicker', () => {
         dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(selectedDate.date().toFixed(0));
 
-        dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(selectedDate.format('MM/DD/YYYY'));
+        dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(selectedDate.format('DD/MMM/YYYY'));
 
     })
 
@@ -120,7 +120,7 @@ describe('DatePicker', () => {
         const fiveDaysFromToday = moment().add(5, 'days');
         const {container, getByPlaceholderText, getByTestId} = render(<AppointmentDatePicker value={fiveDaysFromToday}
                                                                                 isDisabled={true}/>);
-        let dateInputField = getByPlaceholderText('mm/dd/yyyy');
+        let dateInputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(dateInputField.disabled).toBe(true);
         const dateCalendarContainer = getByTestId('datePicker-Calendar');
         expect(dateCalendarContainer).toHaveAttribute('disabled');
@@ -131,7 +131,7 @@ describe('DatePicker', () => {
         const fiveDaysFromToday = moment().add(5, 'days');
         const {container, getByPlaceholderText, getByTestId} = render(<AppointmentDatePicker value={fiveDaysFromToday}
                                                                                              isDisabled={false}/>);
-        let dateInputField = getByPlaceholderText('mm/dd/yyyy');
+        let dateInputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(dateInputField.disabled).toBe(false);
         const dateCalendarContainer = getByTestId('datePicker-Calendar');
         expect(dateCalendarContainer).not.toHaveAttribute('disabled');
@@ -141,7 +141,7 @@ describe('DatePicker', () => {
         const fiveDaysFromToday = moment().add(5, 'days');
         const {container, getByPlaceholderText, getByTestId} = render(<AppointmentDatePicker value={fiveDaysFromToday}
                                                                                              isDisabled={true}/>);
-        let dateInputField = getByPlaceholderText('mm/dd/yyyy');
+        let dateInputField = getByPlaceholderText('dd/mmm/yyyy');
         expect(dateInputField.disabled).toBe(true);
         const dateCalendarContainer = getByTestId('datePicker-Calendar');
         expect(dateCalendarContainer).toHaveAttribute('disabled');
@@ -191,15 +191,15 @@ describe('DatePicker', () => {
                                                                         minDate={minDate}/>);
         let dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(fiveDaysFromToday.date().toFixed(0));
-        const dateInputField = getByPlaceholderText('mm/dd/yyyy');
-        expect(dateInputField.value).toBe(fiveDaysFromToday.format('MM/DD/YYYY'));
+        const dateInputField = getByPlaceholderText('dd/mmm/yyyy');
+        expect(dateInputField.value).toBe(fiveDaysFromToday.format('DD/MMM/YYYY'));
 
-        fireEvent.change(dateInputField, {target:{value: newSelectedDate.format('MM/DD/YYYY')}})
+        fireEvent.change(dateInputField, {target:{value: newSelectedDate.format('DD/MMM/YYYY')}})
         fireEvent.blur(dateInputField);
 
         dateSelectedField = container.querySelector('.react-datepicker__day--selected');
         expect(dateSelectedField.textContent).toBe(newSelectedDate.date().toFixed(0));
-        expect(dateInputField.value).toBe(newSelectedDate.format('MM/DD/YYYY'));
+        expect(dateInputField.value).toBe(newSelectedDate.format('DD/MMM/YYYY'));
 
         let datePickerHeader = getByTestId('date-picker-header-label');
         const monthYearHeader = datePickerHeader.childNodes[0];

--- a/ui/react-components/stories/DateInput.stories.js
+++ b/ui/react-components/stories/DateInput.stories.js
@@ -1,9 +1,9 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import DateInput from '../components/DatePicker/DateInput.jsx';
 import moment from "moment";
 
 export default { title: 'Date Input' };
 
-export const basic = () => (<DateInput value={moment().format('MM/DD/YYYY')}></DateInput>);
+export const basic = () => (<DateInput value={moment().format('DD/MMM/YYYY')}></DateInput>);
 
-export const withOnBlur = () => (<DateInput value={moment().format('MM/DD/YYYY')}></DateInput>);
+export const withOnBlur = () => (<DateInput value={moment().format('DD/MMM/YYYY')}></DateInput>);

--- a/ui/react-components/utils/DateUtil.js
+++ b/ui/react-components/utils/DateUtil.js
@@ -14,33 +14,14 @@ export const isStartTimeBeforeEndTime = (startDateTime, endDateTime) => {
 
 export const isValidUSDate= (dateValue) =>{
     let selectedDate = dateValue;
-    if (selectedDate == '' || _.isNil(selectedDate))
-        return false;
 
-    let regExp = /^(\d{1,2})(\/|-)(\d{1,2})(\/|-)(\d{4})$/;
-    var dateArray = selectedDate.match(regExp);
-
-    if (dateArray == null) {
+    if (_.isNil(selectedDate) || selectedDate === '') {
         return false;
     }
 
-    let month = dateArray[1];
-    let day = dateArray[3];
-    let year = dateArray[5];
-
-    if (month < 1 || month > 12) {
-        return false;
-    } else if (day < 1 || day > 31) {
-        return false;
-    } else if ((month == 4 || month == 6 || month == 9 || month == 11) && day == 31) {
-        return false;
-    } else if (month == 2) {
-        var isLeapYear = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
-        if (day > 29 || (day == 29 && !isLeapYear)) {
-            return false
-        }
-    }
-    return true;
+    selectedDate = moment(selectedDate, "DD/MMM/YYYY", true);
+    return selectedDate.isValid();
+    
 }
 
 const getDateWithoutTime = (datetime) => {

--- a/ui/react-components/utils/DateUtil.js
+++ b/ui/react-components/utils/DateUtil.js
@@ -12,7 +12,7 @@ export const isStartTimeBeforeEndTime = (startDateTime, endDateTime) => {
     return (!startDateTime || !endDateTime) || moment(startDateTime).isBefore(moment(endDateTime));
 };
 
-export const isValidUSDate= (dateValue) =>{
+export const isValidDate= (dateValue) =>{
     let selectedDate = dateValue;
 
     if (_.isNil(selectedDate) || selectedDate === '') {

--- a/ui/react-components/utils/DateUtil.spec.js
+++ b/ui/react-components/utils/DateUtil.spec.js
@@ -1,77 +1,77 @@
 import{
-    isValidUSDate
+    isValidDate
 } from "./DateUtil";
 
 describe('DateUtil', () =>{
     it('should return true when a valid date is passed', ()=>{
-        const isValid = isValidUSDate('12/Feb/2019');
+        const isValid = isValidDate('12/Feb/2019');
         expect(isValid).toBe(true)
 
     })
 
     it('should return false when a no date is passed', ()=>{
-        const isValid = isValidUSDate();
+        const isValid = isValidDate();
         expect(isValid).toBe(false)
 
     })
 
     it('should return false when an invalid date format is passed', ()=>{
-        const isValid = isValidUSDate('01/Feb');
+        const isValid = isValidDate('01/Feb');
         expect(isValid).toBe(false)
 
     })
 
     it('should return false when an invalid date with valid format is passed', ()=>{
-        const isValid = isValidUSDate('30/Feb/2019');
+        const isValid = isValidDate('30/Feb/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when an invalid month  is passed', ()=>{
-        const isValid = isValidUSDate('30/Hui/2019');
+        const isValid = isValidDate('30/Hui/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when an invalid date  is passed', ()=>{
-        const isValid = isValidUSDate('32/Dec/2019');
+        const isValid = isValidDate('32/Dec/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when month is 4,6,9 or 11 and date is 31', ()=>{
-        let isValid = isValidUSDate('31/Nov/2019');
+        let isValid = isValidDate('31/Nov/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('31/Sep/2019');
+        isValid = isValidDate('31/Sep/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('31/Jun/2019');
+        isValid = isValidDate('31/Jun/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('31/Apr/2019');
+        isValid = isValidDate('31/Apr/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return true when month is 1,3,5,7,8,10 or 12 and date is 31', ()=>{
-        let isValid = isValidUSDate('31/Jan/2019');
+        let isValid = isValidDate('31/Jan/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/Mar/2019');
+        isValid = isValidDate('31/Mar/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/May/2019');
+        isValid = isValidDate('31/May/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/Jul/2019');
+        isValid = isValidDate('31/Jul/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/Aug/2019');
+        isValid = isValidDate('31/Aug/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/Oct/2019');
+        isValid = isValidDate('31/Oct/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('31/Dec/2019');
+        isValid = isValidDate('31/Dec/2019');
         expect(isValid).toBe(true)
     })
 
     it('should return true when it is a leapyear and date is 29', ()=>{
-        let isValid = isValidUSDate('29/Feb/2020');
+        let isValid = isValidDate('29/Feb/2020');
         expect(isValid).toBe(true)
 
     })
 
     it('should return false when it is a leapyear and date is above 29', ()=>{
-        let isValid = isValidUSDate('30/Feb/2020');
+        let isValid = isValidDate('30/Feb/2020');
         expect(isValid).toBe(false)
 
     })

--- a/ui/react-components/utils/DateUtil.spec.js
+++ b/ui/react-components/utils/DateUtil.spec.js
@@ -4,7 +4,7 @@ import{
 
 describe('DateUtil', () =>{
     it('should return true when a valid date is passed', ()=>{
-        const isValid = isValidUSDate('02/12/2019');
+        const isValid = isValidUSDate('12/Feb/2019');
         expect(isValid).toBe(true)
 
     })
@@ -16,62 +16,62 @@ describe('DateUtil', () =>{
     })
 
     it('should return false when an invalid date format is passed', ()=>{
-        const isValid = isValidUSDate('01/02');
+        const isValid = isValidUSDate('01/Feb');
         expect(isValid).toBe(false)
 
     })
 
     it('should return false when an invalid date with valid format is passed', ()=>{
-        const isValid = isValidUSDate('30/02/2019');
+        const isValid = isValidUSDate('30/Feb/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when an invalid month  is passed', ()=>{
-        const isValid = isValidUSDate('30/30/2019');
+        const isValid = isValidUSDate('30/Hui/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when an invalid date  is passed', ()=>{
-        const isValid = isValidUSDate('12/32/2019');
+        const isValid = isValidUSDate('32/Dec/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return false when month is 4,6,9 or 11 and date is 31', ()=>{
-        let isValid = isValidUSDate('11/31/2019');
+        let isValid = isValidUSDate('31/Nov/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('9/31/2019');
+        isValid = isValidUSDate('31/Sep/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('6/31/2019');
+        isValid = isValidUSDate('31/Jun/2019');
         expect(isValid).toBe(false)
-        isValid = isValidUSDate('4/31/2019');
+        isValid = isValidUSDate('31/Apr/2019');
         expect(isValid).toBe(false)
     })
 
     it('should return true when month is 1,3,5,7,8,10 or 12 and date is 31', ()=>{
-        let isValid = isValidUSDate('1/31/2019');
+        let isValid = isValidUSDate('31/Jan/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('3/31/2019');
+        isValid = isValidUSDate('31/Mar/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('5/31/2019');
+        isValid = isValidUSDate('31/May/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('7/31/2019');
+        isValid = isValidUSDate('31/Jul/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('8/31/2019');
+        isValid = isValidUSDate('31/Aug/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('10/31/2019');
+        isValid = isValidUSDate('31/Oct/2019');
         expect(isValid).toBe(true)
-        isValid = isValidUSDate('12/31/2019');
+        isValid = isValidUSDate('31/Dec/2019');
         expect(isValid).toBe(true)
     })
 
     it('should return true when it is a leapyear and date is 29', ()=>{
-        let isValid = isValidUSDate('2/29/2020');
+        let isValid = isValidUSDate('29/Feb/2020');
         expect(isValid).toBe(true)
 
     })
 
     it('should return false when it is a leapyear and date is above 29', ()=>{
-        let isValid = isValidUSDate('2/30/2020');
+        let isValid = isValidUSDate('30/Feb/2020');
         expect(isValid).toBe(false)
 
     })


### PR DESCRIPTION
This PR fixes the date format in create appointment page to be shown as dd/mmm/yyyy (Ex. 22/Jan/2024). This makes it consistent with other places where appointment list is shown.
- Also the `isValidUSDate` function is refactored to remove custom regex based validation and uses moment isValid function
<img width="379" alt="image" src="https://github.com/Bahmni/openmrs-module-appointments-frontend/assets/31698165/72d31ac5-036c-4c69-9cad-df2438bf94d4">
