### PR TITLE
BAH-3647 | Add. Event Trigger To Publish openmrs-module-appointments-frontend

### DIFF
--- a/.github/workflows/deploy_publish.yml
+++ b/.github/workflows/deploy_publish.yml
@@ -8,6 +8,12 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
       - "**.md"
+  workflow_run:
+    workflows: [Pull Translations from Transifex]
+    types: [completed]
+    branches:
+      - master
+      - 'release-*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
JIRA -> [BAH-3646](https://bahmni.atlassian.net/browse/BAH-3646)

In this PR, an workflow based event trigger has been added to the Build and Publish openmrs-module-appointments-frontend workflow. The Build and Publish openmrs-module-appointments-frontend workflow was not getting triggered as the commit action in the Pull Translations From Transifex workflow run can’t trigger a new workflow run [(Refer comment)](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360). The changes added will programmatically trigger Build and Publish openmrs-module-appointments-frontend once the Pull Translations From Transifex workflow is successfully completed.