### PR TITLE
A-1207131329891848 | Filtering on Awaiting Appointments should query the backend

### DIFF
--- a/i18n/appointments/locale_en.json
+++ b/i18n/appointments/locale_en.json
@@ -216,6 +216,7 @@
   "RECURRENCE_WEEKDAYS_ERROR_MESSAGE": "Please select the day(s)",
   "NO_CONTENT_ERROR_MESSAGE": "Selected days do not fall under the end date selected",
   "UNEXPECTED_SERVICE_ERROR": "There was an unexpected issue on the server. Please try again",
+  "APPOINTMENT_SEARCH_TIME_ERROR": "Connection timed out. The request took too long to complete.",
   "PRIORITY_ERROR_MESSAGE": "Please select appointment category",
   "STATUS_ERROR_MESSAGE": "Please select appointment status",
   "PUBLIC_HOLIDAY_WARNING": "Date selected is a Public Holiday",

--- a/src/controllers/manage/appointmentsCreateController.js
+++ b/src/controllers/manage/appointmentsCreateController.js
@@ -157,7 +157,7 @@ angular.module('bahmni.appointments')
 
             $scope.onSelectPatient = function (data) {
                 $scope.appointment.patient = data;
-                return spinner.forPromise(appointmentsService.search({patientUuid: data.uuid}).then(function (oldAppointments) {
+                return spinner.forPromise(appointmentsService.search({patientUuids: [data.uuid]}).then(function (oldAppointments) {
                     $scope.patientAppointments = oldAppointments.data;
                 }));
             };

--- a/src/controllers/manage/appointmentsFilterController.js
+++ b/src/controllers/manage/appointmentsFilterController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .controller('AppointmentsFilterController', ['$scope', '$state', '$rootScope', '$q', '$translate', 'appointmentsServiceService', 'spinner', 'ivhTreeviewMgr', 'providerService', 'appService', 'locationService',
-        function ($scope, $state, $rootScope, $q, $translate, appointmentsServiceService, spinner, ivhTreeviewMgr, providerService, appService, locationService) {
+    .controller('AppointmentsFilterController', ['$scope', '$state', '$rootScope', '$q', '$translate', 'appointmentsServiceService', 'spinner', 'ivhTreeviewMgr', 'providerService', 'appService', 'locationService', 'appointmentsService',
+        function ($scope, $state, $rootScope, $q, $translate, appointmentsServiceService, spinner, ivhTreeviewMgr, providerService, appService, locationService, appointmentsService) {
             var init = function () {
                 $scope.isSpecialityEnabled = appService.getAppDescriptor().getConfigValue('enableSpecialities');
                 $scope.isServiceTypeEnabled = appService.getAppDescriptor().getConfigValue('enableServiceTypes');
@@ -254,6 +254,14 @@ angular.module('bahmni.appointments')
                 $state.params.filterParams.statusList = _.map($scope.selectedStatusList, function (status) {
                     return status.value;
                 });
+                const AWAITING_APPOINTMENTS_TAB_NAME = "awaitingappointments";
+                if($state.current.tabName === AWAITING_APPOINTMENTS_TAB_NAME) {
+                    let payload = $state.params.filterParams;
+                    payload.withoutDates = true;
+                    spinner.forPromise(appointmentsService.search(payload).then(function (response) {
+                        $rootScope.appointmentsData = response.data;
+                    }));
+                }
             };
 
             $scope.isFilterApplied = function () {

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -109,7 +109,7 @@ angular.module('bahmni.appointments')
                 else
                 return appointmentsService.search( prefilledPatient ? { patientUuid: prefilledPatient } : APPOINTMENT_STATUS_WAITLIST)
                 .then((response) => updateAppointments(response))
-                .catch((error) => messagingService.showMessage('error', 'UNEXPECTED_SERVICE_ERROR'));
+                .catch((error) => messagingService.showMessage('error', 'APPOINTMENT_SEARCH_TIME_ERROR'));
             };
 
             var updateAppointments = function (response){

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -107,7 +107,7 @@ angular.module('bahmni.appointments')
                     .then((response) => updateAppointments(response));
                 }
                 else
-                return appointmentsService.search( prefilledPatient ? { patientUuid: prefilledPatient } : APPOINTMENT_STATUS_WAITLIST)
+                return appointmentsService.search( prefilledPatient ? { patientUuids: [prefilledPatient] } : APPOINTMENT_STATUS_WAITLIST)
                 .then((response) => updateAppointments(response))
                 .catch((error) => messagingService.showMessage('error', 'APPOINTMENT_SEARCH_TIME_ERROR'));
             };
@@ -151,7 +151,7 @@ angular.module('bahmni.appointments')
             }
 
             var setAppointmentsInPatientSearch = function (patientUuid) {
-                appointmentsService.search({patientUuid: patientUuid}).then(function (response) {
+                appointmentsService.search({patientUuids: [patientUuid]}).then(function (response) {
                     var appointmentsInDESCOrderBasedOnStartDateTime = _.sortBy(response.data, "startDateTime").reverse();
                     setFilteredAppointmentsInPatientSearch(appointmentsInDESCOrderBasedOnStartDateTime);
                 });

--- a/src/controllers/manage/list/appointmentsListViewController.js
+++ b/src/controllers/manage/list/appointmentsListViewController.js
@@ -31,7 +31,7 @@ angular.module('bahmni.appointments')
             var enableAutoRefresh = !isNaN(autoRefreshIntervalInSeconds);
             var autoRefreshStatus = true;
             const APPOINTMENT_STATUS_WAITLIST = {
-                "isDatelessAppointments": true
+                "withoutDates": true
             }
             const APPOINTMENTS_TAB_NAME = "appointments";
             const AWAITING_APPOINTMENTS_TAB_NAME = "awaitingappointments";
@@ -108,7 +108,8 @@ angular.module('bahmni.appointments')
                 }
                 else
                 return appointmentsService.search( prefilledPatient ? { patientUuid: prefilledPatient } : APPOINTMENT_STATUS_WAITLIST)
-                .then((response) => updateAppointments(response));
+                .then((response) => updateAppointments(response))
+                .catch((error) => messagingService.showMessage('error', 'UNEXPECTED_SERVICE_ERROR'));
             };
 
             var updateAppointments = function (response){

--- a/src/directives/patientSearch.js
+++ b/src/directives/patientSearch.js
@@ -27,7 +27,7 @@ angular.module('bahmni.appointments')
 
                     $scope.onSelectPatient = function (data) {
                         $state.params.patient = data;
-                        spinner.forPromise(appointmentsService.search({patientUuid: data.uuid}).then(function (oldAppointments) {
+                        spinner.forPromise(appointmentsService.search({patientUuids: [data.uuid]}).then(function (oldAppointments) {
                             var appointmentInDESCOrderBasedOnStartDateTime = _.sortBy(oldAppointments.data, "startDateTime").reverse();
                             $scope.onSearch(appointmentInDESCOrderBasedOnStartDateTime);
                         }));

--- a/test/controllers/manage/appointmentsCreateController.spec.js
+++ b/test/controllers/manage/appointmentsCreateController.spec.js
@@ -284,7 +284,7 @@ describe("AppointmentsCreateController", function () {
             $scope.patientAppointments = undefined;
             var patientUuid = 'uuid';
             appointmentContext = {appointment: {patient:{uuid: patientUuid}}};
-            var appointmentSearchParams = {patientUuid: patientUuid};
+            var appointmentSearchParams = {patientUuids: [patientUuid]};
             createController();
 
             expect(appointmentsService.search).toHaveBeenCalledWith(appointmentSearchParams);

--- a/test/controllers/manage/appointmentsFilterController.spec.js
+++ b/test/controllers/manage/appointmentsFilterController.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('AppointmentsFilterController', function () {
-    var controller, scope, state, appService, appDescriptor, appointmentsServiceService, ivhTreeviewMgr, q, translate;
+    var controller, scope, state, appService, appDescriptor, appointmentsServiceService, ivhTreeviewMgr, q, translate, appointmentsService;
     var locationService = jasmine.createSpyObj('locationService', ['getAllByTag']);
     var providerService = jasmine.createSpyObj('providerService', ['list']);
     var appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
@@ -93,6 +93,7 @@ describe('AppointmentsFilterController', function () {
             appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
             appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
             appointmentsServiceService = jasmine.createSpyObj('appointmentsServiceService', ['getAllServicesWithServiceTypes']);
+            appointmentsService = jasmine.createSpyObj('appointmentsService', ['search']);
             ivhTreeviewMgr = jasmine.createSpyObj('ivhTreeviewMgr', ['deselectAll', 'selectEach', 'collapseRecursive']);
             translate = jasmine.createSpyObj('$translate', ['instant']);
             appService.getAppDescriptor.and.returnValue(appDescriptor);
@@ -115,6 +116,7 @@ describe('AppointmentsFilterController', function () {
             $scope: scope,
             appService: appService,
             appointmentsServiceService: appointmentsServiceService,
+            appointmentsService: appointmentsService,
             $state: state,
             ivhTreeviewMgr: ivhTreeviewMgr,
             $q: q,
@@ -799,5 +801,21 @@ describe('AppointmentsFilterController', function () {
         q.all.and.returnValue(specUtil.simplePromise([servicesWithTypes, providers, locations]));
         createController();
         expect(scope.providers.length).toBe(2)
+    });
+
+    it("should make appointments search call when in awaiting appointments tab when filters are clicked", function() {
+        q.all.and.returnValue(specUtil.simplePromise([servicesWithTypes, providers, locations]));
+        createController();
+        state.current.tabName = "awaitingappointments";
+        appointmentsService.search.and.returnValue(specUtil.simplePromise({data: []}));
+        scope.applyFilter();
+        expect(appointmentsService.search).toHaveBeenCalledWith({
+            serviceUuids: [],
+            serviceTypeUuids : [],
+            providerUuids: [],
+            locationUuids: [],
+            statusList: [],
+            withoutDates: true
+        });
     });
 });

--- a/test/directives/patientSearch.spec.js
+++ b/test/directives/patientSearch.spec.js
@@ -69,7 +69,7 @@ describe("Patient Search", function () {
         var patient = {uuid: 'patientUuid'};
         compiledScope.onSelectPatient(patient);
         expect(state.params.patient).toEqual(patient);
-        expect(appointmentsService.search).toHaveBeenCalledWith({patientUuid: patient.uuid});
+        expect(appointmentsService.search).toHaveBeenCalledWith({patientUuids: [patient.uuid]});
         expect(scope.displaySearchedPatient).toHaveBeenCalled();
     });
 
@@ -90,7 +90,7 @@ describe("Patient Search", function () {
         var element = createElement();
         var compiledScope = element.isolateScope();
         expect(compiledScope.patient).toBe(patient.givenName + " " + patient.familyName + " " + "(" + patient.identifier + ")");
-        expect(appointmentsService.search).toHaveBeenCalledWith({patientUuid: patient.uuid});
+        expect(appointmentsService.search).toHaveBeenCalledWith({patientUuids: [patient.uuid]});
         expect(scope.displaySearchedPatient).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
https://app.asana.com/0/1204322126657135/1207131329891848

# Summary

This PR has changes to allow making API calls to backend when a new filter is chosen. This is only done in the case of awaiting appointments