### PR TITLE
BAH-4110 | Fix. Bump Vulnerable Base Image Version

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM httpd:2.4.59-alpine3.20
+FROM httpd:2.4.62-alpine3.20
 COPY dist/. /usr/local/apache2/htdocs/appointments/


### PR DESCRIPTION
JIRA -> [BAH-4110](https://bahmni.atlassian.net/browse/BAH-4110)

This PR updates the base image for the Appointments Docker image from `httpd:2.4.59-alpine3.20` to `httpd:2.4.62-alpine3.20` to address security vulnerabilities identified in the previous version.

Changes:
Updated the Dockerfile to use httpd:2.4.62-alpine3.20 as the base image.