### PR TITLE
BAH-4229 | Add. Support For Additional Attributes Types For Appointments

### DIFF
--- a/config/ng-config.json
+++ b/config/ng-config.json
@@ -91,6 +91,7 @@
       "homeUrl": "../../bahmni/home",
       "createServiceUrl": "/openmrs/ws/rest/v1/appointmentService",
       "getServiceLoad": "/openmrs/ws/rest/v1/appointmentService/load",
+      "appointmentServiceAttributeTypesUrl": "/openmrs/ws/rest/v1/appointment-service-attribute-types",
       "getAllSpecialitiesUrl": "/openmrs/ws/rest/v1/speciality/all",
       "createAppointmentUrl": "/openmrs/ws/rest/v1/appointment",
       "getAppointmentsForServiceTypeUrl": "/openmrs/ws/rest/v1/appointment/futureAppointmentsForServiceType/",

--- a/src/controllers/admin/appointmentServiceController.js
+++ b/src/controllers/admin/appointmentServiceController.js
@@ -150,7 +150,7 @@ angular.module('bahmni.appointments')
             };
 
             var initAttributeTypes = function () {
-                return appointmentsServiceService.getAllAttributeTypes().then(function (response) {
+                return appointmentsServiceService.getAllNonVoidedAttributeTypes().then(function (response) {
                     $scope.attributeTypes = response.data;
                 });
             };

--- a/src/controllers/admin/appointmentServiceController.js
+++ b/src/controllers/admin/appointmentServiceController.js
@@ -121,10 +121,17 @@ angular.module('bahmni.appointments')
                 });
             };
 
+            var initAttributeTypes = function () {
+                return appointmentsServiceService.getAllAttributeTypes().then(function (response) {
+                    $scope.attributeTypes = response.data;
+                });
+            };
+
             var init = function () {
                 var promises = [];
                 promises.push(initAppointmentLocations());
                 promises.push(initServices());
+                promises.push(initAttributeTypes());
                 if ($scope.enableSpecialities) {
                     promises.push(initSpecialities());
                 }

--- a/src/directives/serviceAttributes.js
+++ b/src/directives/serviceAttributes.js
@@ -1,0 +1,138 @@
+'use strict';
+
+angular.module('bahmni.appointments')
+    .directive('serviceAttributes', ['messagingService', function (messagingService) {
+        var controller = ['$scope', function ($scope) {
+            $scope.attributeValues = {};
+
+            var init = function () {
+                if (!$scope.service) {
+                    $scope.service = {};
+                }
+                if (!$scope.service.attributes) {
+                    $scope.service.attributes = [];
+                }
+                _.each($scope.service.attributes, function (attr) {
+                    if (!attr.voided) {
+                        $scope.attributeValues[attr.attributeTypeUuid] = attr.value;
+                    }
+                });
+            };
+
+            $scope.getAttributeValue = function (attributeTypeUuid) {
+                return $scope.attributeValues[attributeTypeUuid] || '';
+            };
+
+            $scope.addOrUpdateAttribute = function (attributeTypeUuid, attributeTypeName, value) {
+                if (!$scope.service.attributes) {
+                    $scope.service.attributes = [];
+                }
+
+                var existingAttr = _.find($scope.service.attributes, function (attr) {
+                    return attr.attributeTypeUuid === attributeTypeUuid && !attr.voided;
+                });
+
+                if (value && value.trim() !== '') {
+                    if (existingAttr) {
+                        existingAttr.value = value;
+                    } else {
+                        $scope.service.attributes.push({
+                            attributeTypeUuid: attributeTypeUuid,
+                            value: value,
+                            voided: false
+                        });
+                    }
+                    $scope.attributeValues[attributeTypeUuid] = value;
+                } else {
+                    $scope.removeAttribute(attributeTypeUuid);
+                }
+            };
+
+            $scope.removeAttribute = function (attributeTypeUuid) {
+                var existingAttr = _.find($scope.service.attributes, function (attr) {
+                    return attr.attributeTypeUuid === attributeTypeUuid && !attr.voided;
+                });
+
+                if (existingAttr) {
+                    if (!_.isEmpty(existingAttr.uuid)) {
+                        existingAttr.voided = true;
+                    } else {
+                        _.remove($scope.service.attributes, existingAttr);
+                    }
+                }
+
+                delete $scope.attributeValues[attributeTypeUuid];
+            };
+
+            var validateCardinality = function (attrType) {
+                var nonVoidedAttrs = _.filter($scope.service.attributes, function (attr) {
+                    return attr.attributeTypeUuid === attrType.uuid && !attr.voided;
+                });
+
+                var count = nonVoidedAttrs.length;
+                var errors = [];
+
+                if (attrType.minOccurs && count < attrType.minOccurs) {
+                    errors.push("Attribute '" + attrType.name + "' requires at least " + attrType.minOccurs + " occurrence(s), but only " + count + " provided");
+                }
+
+                if (attrType.maxOccurs && count > attrType.maxOccurs) {
+                    errors.push("Attribute '" + attrType.name + "' allows maximum " + attrType.maxOccurs + " occurrence(s), but " + count + " provided");
+                }
+
+                return errors;
+            };
+
+            $scope.validateAttributes = function () {
+                if (!$scope.attributeTypes) {
+                    return true;
+                }
+
+                var errors = [];
+                _.each($scope.attributeTypes, function (attrType) {
+                    errors = errors.concat(validateCardinality(attrType));
+                });
+
+                if (errors.length > 0) {
+                    messagingService.showMessage('error', errors.join('; '));
+                    return false;
+                }
+
+                return true;
+            };
+
+            $scope.isRequired = function (attributeType) {
+                return attributeType && attributeType.minOccurs && attributeType.minOccurs > 0;
+            };
+
+            $scope.getInputType = function (datatype) {
+                if (!datatype) {
+                    return 'text';
+                }
+
+                var lowerDatatype = datatype.toLowerCase();
+
+                if (lowerDatatype.indexOf('boolean') !== -1) {
+                    return 'checkbox';
+                } else if (lowerDatatype.indexOf('number') !== -1 || lowerDatatype.indexOf('integer') !== -1) {
+                    return 'number';
+                } else if (lowerDatatype.indexOf('date') !== -1) {
+                    return 'date';
+                } else {
+                    return 'text';
+                }
+            };
+
+            init();
+        }];
+
+        return {
+            restrict: 'E',
+            scope: {
+                service: '=',
+                attributeTypes: '='
+            },
+            template: require("../views/admin/serviceAttributes.html"),
+            controller: controller
+        };
+    }]);

--- a/src/directives/serviceAttributes.js
+++ b/src/directives/serviceAttributes.js
@@ -1,9 +1,13 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .directive('serviceAttributes', [function () {
+    .directive('serviceAttributes', ['appointmentCommonService', function (appointmentCommonService) {
         var controller = ['$scope', function ($scope) {
             $scope.attributeValues = {};
+
+            $scope.hasPrivilege = function (privilege) {
+                return appointmentCommonService.hasPrivilege(privilege);
+            };
 
             var init = function () {
                 if (!$scope.service) {

--- a/src/directives/serviceAttributes.js
+++ b/src/directives/serviceAttributes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .directive('serviceAttributes', ['messagingService', function (messagingService) {
+    .directive('serviceAttributes', [function () {
         var controller = ['$scope', function ($scope) {
             $scope.attributeValues = {};
 
@@ -62,43 +62,6 @@ angular.module('bahmni.appointments')
                 }
 
                 delete $scope.attributeValues[attributeTypeUuid];
-            };
-
-            var validateCardinality = function (attrType) {
-                var nonVoidedAttrs = _.filter($scope.service.attributes, function (attr) {
-                    return attr.attributeTypeUuid === attrType.uuid && !attr.voided;
-                });
-
-                var count = nonVoidedAttrs.length;
-                var errors = [];
-
-                if (attrType.minOccurs && count < attrType.minOccurs) {
-                    errors.push("Attribute '" + attrType.name + "' requires at least " + attrType.minOccurs + " occurrence(s), but only " + count + " provided");
-                }
-
-                if (attrType.maxOccurs && count > attrType.maxOccurs) {
-                    errors.push("Attribute '" + attrType.name + "' allows maximum " + attrType.maxOccurs + " occurrence(s), but " + count + " provided");
-                }
-
-                return errors;
-            };
-
-            $scope.validateAttributes = function () {
-                if (!$scope.attributeTypes) {
-                    return true;
-                }
-
-                var errors = [];
-                _.each($scope.attributeTypes, function (attrType) {
-                    errors = errors.concat(validateCardinality(attrType));
-                });
-
-                if (errors.length > 0) {
-                    messagingService.showMessage('error', errors.join('; '));
-                    return false;
-                }
-
-                return true;
             };
 
             $scope.isRequired = function (attributeType) {

--- a/src/init.js
+++ b/src/init.js
@@ -83,6 +83,7 @@ require("./directives/weekCalendar.js");
 require("./directives/weekdaySelector.js");
 require("./directives/serviceAvailability.js");
 require("./directives/serviceTypes.js");
+require("./directives/serviceAttributes.js");
 require("./directives/colorPicker.js");
 require("./directives/datePicker.js");
 require("./directives/weekPicker.js");

--- a/src/models/appointmentService.js
+++ b/src/models/appointmentService.js
@@ -46,7 +46,8 @@ Bahmni.Appointments.AppointmentService = (function () {
             specialityUuid: serviceDetails.specialityUuid,
             locationUuid: serviceDetails.locationUuid,
             weeklyAvailability: parse(serviceDetails.weeklyAvailability),
-            serviceTypes: serviceDetails.serviceTypes || []
+            serviceTypes: serviceDetails.serviceTypes || [],
+            attributes: serviceDetails.attributes || []
         });
         return service;
     };

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -55,7 +55,7 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
             });
         };
 
-        var parseAttributes = function (attributes) {
+        var parseNonVoidedAttributes = function (attributes) {
             if (!attributes || !attributes.length) {
                 return [];
             }
@@ -86,7 +86,7 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
             locationUuid: serviceDetails.location ? serviceDetails.location.uuid : undefined,
             weeklyAvailability: parseAvailability(serviceDetails.weeklyAvailability) || [],
             serviceTypes: serviceDetails.serviceTypes || [],
-            attributes: parseAttributes(serviceDetails.attributes)
+            attributes: parseNonVoidedAttributes(serviceDetails.attributes)
         });
         return service;
     };

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -55,6 +55,23 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
             });
         };
 
+        var parseAttributes = function (attributes) {
+            if (!attributes || !attributes.length) {
+                return [];
+            }
+            return attributes.filter(function (attr) {
+                return !attr.voided;
+            }).map(function (attr) {
+                return {
+                    uuid: attr.uuid,
+                    attributeTypeUuid: attr.attributeTypeUuid,
+                    attributeType: attr.attributeType,
+                    value: attr.value,
+                    voided: attr.voided || false
+                };
+            });
+        };
+
         var service = new Service({
             name: serviceDetails.name,
             uuid: serviceDetails.uuid,
@@ -68,7 +85,8 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
             specialityUuid: serviceDetails.speciality ? serviceDetails.speciality.uuid : undefined,
             locationUuid: serviceDetails.location ? serviceDetails.location.uuid : undefined,
             weeklyAvailability: parseAvailability(serviceDetails.weeklyAvailability) || [],
-            serviceTypes: serviceDetails.serviceTypes || []
+            serviceTypes: serviceDetails.serviceTypes || [],
+            attributes: parseAttributes(serviceDetails.attributes)
         });
         return service;
     };

--- a/src/services/appointmentsServiceService.js
+++ b/src/services/appointmentsServiceService.js
@@ -1,58 +1,100 @@
-'use strict';
+"use strict";
 
-angular.module('bahmni.appointments')
-    .service('appointmentsServiceService', ['$http',
-        function ($http) {
-            this.save = function (service) {
-                return $http.post(Bahmni.Appointments.Constants.createServiceUrl, service, {
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+angular.module("bahmni.appointments").service("appointmentsServiceService", [
+  "$http",
+  function ($http) {
+    this.save = function (service) {
+      return $http.post(
+        Bahmni.Appointments.Constants.createServiceUrl,
+        service,
+        {
+          withCredentials: true,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    };
 
-            this.getAllServices = function () {
-                return $http.get(Bahmni.Common.Constants.appointmentServiceUrl + "/all/default", {
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+    this.getAllServices = function () {
+      return $http.get(
+        Bahmni.Common.Constants.appointmentServiceUrl + "/all/default",
+        {
+          withCredentials: true,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    };
 
-            this.getAllServicesWithServiceTypes = function () {
-                return $http.get(Bahmni.Common.Constants.appointmentServiceUrl + "/all/full", {
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+    this.getAllServicesWithServiceTypes = function () {
+      return $http.get(
+        Bahmni.Common.Constants.appointmentServiceUrl + "/all/full",
+        {
+          withCredentials: true,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    };
 
-            this.getServiceLoad = function (serviceUuid, startDateTime, endDateTime) {
-                var params = {uuid: serviceUuid, startDateTime: startDateTime, endDateTime: endDateTime};
-                return $http.get(Bahmni.Appointments.Constants.getServiceLoad, {
-                    params: params,
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+    this.getServiceLoad = function (serviceUuid, startDateTime, endDateTime) {
+      var params = {
+        uuid: serviceUuid,
+        startDateTime: startDateTime,
+        endDateTime: endDateTime,
+      };
+      return $http.get(Bahmni.Appointments.Constants.getServiceLoad, {
+        params: params,
+        withCredentials: true,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      });
+    };
 
-            this.getService = function (uuid) {
-                return $http.get(Bahmni.Common.Constants.appointmentServiceUrl + "?uuid=" + uuid, {
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+    this.getService = function (uuid) {
+      return $http.get(
+        Bahmni.Common.Constants.appointmentServiceUrl + "?uuid=" + uuid,
+        {
+          withCredentials: true,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    };
 
-            this.deleteAppointmentService = function (serviceUuid) {
-                var params = {uuid: serviceUuid};
-                return $http.delete(Bahmni.Common.Constants.appointmentServiceUrl, {
-                    params: params,
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
+    this.deleteAppointmentService = function (serviceUuid) {
+      var params = { uuid: serviceUuid };
+      return $http.delete(Bahmni.Common.Constants.appointmentServiceUrl, {
+        params: params,
+        withCredentials: true,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      });
+    };
 
-            this.getAllAttributeTypes = function () {
-                return $http.get(Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl, {
-                    withCredentials: true,
-                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
-                });
-            };
-        }]);
+    this.getAllNonVoidedAttributeTypes = function () {
+      return $http.get(
+        Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl,
+        {
+          withCredentials: true,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    };
+  },
+]);

--- a/src/services/appointmentsServiceService.js
+++ b/src/services/appointmentsServiceService.js
@@ -48,4 +48,11 @@ angular.module('bahmni.appointments')
                     headers: {"Accept": "application/json", "Content-Type": "application/json"}
                 });
             };
+
+            this.getAllAttributeTypes = function () {
+                return $http.get(Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl, {
+                    withCredentials: true,
+                    headers: {"Accept": "application/json", "Content-Type": "application/json"}
+                });
+            };
         }]);

--- a/src/styles/appointments/_serviceAppointment.scss
+++ b/src/styles/appointments/_serviceAppointment.scss
@@ -70,12 +70,12 @@
       align-items: center;
       label {
         display: inline-block;
-        min-width: 103px;
+        min-width: 150px;
         font-size: 14px;
         text-align: right;
         color: #656161;
         margin-right: 10px;
-        max-width: 103px;
+        max-width: 150px;
 
       }
       input, textarea, select {

--- a/src/views/admin/appointmentService.html
+++ b/src/views/admin/appointmentService.html
@@ -93,6 +93,9 @@
                 <div ng-if="enableServiceTypes">
                     <service-types service="service"></service-types>
                 </div>
+                <div>
+                    <service-attributes service="service" attribute-types="attributeTypes"></service-attributes>
+                </div>
             </div>
             <div class="add-availability">
                 <h3>{{'APPOINTMENT_SERVICE_AVAILABILITY' | translate}}</h3>

--- a/src/views/admin/serviceAttributes.html
+++ b/src/views/admin/serviceAttributes.html
@@ -1,0 +1,19 @@
+<div class="service-attributes-wrapper">
+    <div class="service-attributes-content" ng-if="attributeTypes && attributeTypes.length > 0">
+        <p ng-repeat="attributeType in attributeTypes" class="attribute-field">
+            <label for="attr-{{attributeType.uuid}}">
+                {{attributeType.name}}
+                <span class="asterick" ng-if="isRequired(attributeType)">*</span>
+            </label> 
+            <input
+                id="attr-{{attributeType.uuid}}"
+                type="{{getInputType(attributeType.datatype)}}"
+                ng-model="attributeValues[attributeType.uuid]"
+                ng-disabled="!hasPrivilege('app:appointments:manageServices')"
+                ng-change="addOrUpdateAttribute(attributeType.uuid, attributeType.name, attributeValues[attributeType.uuid])"
+                placeholder="Enter {{attributeType.name}}"
+                ng-required="isRequired(attributeType)"
+            />
+        </p>
+    </div>
+</div>

--- a/test/controllers/admin/appointmentServiceController.spec.js
+++ b/test/controllers/admin/appointmentServiceController.spec.js
@@ -1,463 +1,600 @@
-'use strict';
+"use strict";
 
 describe("AppointmentServiceController", function () {
-    var controller, scope, q, state, appointmentsServiceService, locationService, messagingService,
-        locations, specialityService, specialities, ngDialog, appointmentServices, appService, appDescriptor,
-        colorsForAppointmentService, appointmentServiceContext, confirmBox, appointmentCommonService;
+  var controller,
+    scope,
+    q,
+    state,
+    appointmentsServiceService,
+    locationService,
+    messagingService,
+    locations,
+    specialityService,
+    specialities,
+    ngDialog,
+    appointmentServices,
+    appService,
+    appDescriptor,
+    colorsForAppointmentService,
+    appointmentServiceContext,
+    confirmBox,
+    appointmentCommonService;
 
-    beforeEach(function () {
-        module('bahmni.appointments');
-        inject(function ($controller, $rootScope, $q) {
-            controller = $controller;
-            scope = $rootScope.$new();
-            q = $q;
-        });
+  beforeEach(function () {
+    module("bahmni.appointments");
+    inject(function ($controller, $rootScope, $q) {
+      controller = $controller;
+      scope = $rootScope.$new();
+      q = $q;
     });
+  });
 
-    beforeEach(function () {
-        appointmentsServiceService = jasmine.createSpyObj('appointmentsServiceService', ['save', 'getAllServices', 'getAllAttributeTypes']);
-        appointmentsServiceService.save.and.returnValue(specUtil.simplePromise({}));
-        appointmentServices = [{name: "Oncology", description: "Cancer treatment"}];
-        appointmentsServiceService.getAllServices.and.returnValue(specUtil.simplePromise({data: appointmentServices}));
-        var attributeTypes = [
-            {uuid: 'attr-type-1', name: 'Color Code', datatype: 'org.openmrs.customdatatype.datatype.FreeTextDatatype', minOccurs: 0, maxOccurs: 1}
-        ];
-        appointmentsServiceService.getAllAttributeTypes.and.returnValue(specUtil.simplePromise({data: attributeTypes}));
-        locationService = jasmine.createSpyObj('locationService', ['getAllByTag']);
-        locations = [
-            {display: "OPD1", uuid: 1},
-            {display: "Registration", uuid: 2}
-        ];
-        locationService.getAllByTag.and.returnValue(specUtil.simplePromise({data: {results: locations}}));
-        messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
-        messagingService.showMessage.and.returnValue({});
-        specialityService = jasmine.createSpyObj('specialityService', ['getAllSpecialities']);
-        specialities = [{name: 'Cardiology', uuid: '81da9590-3f10-11e4-2908-0800271c1b75'}];
-        specialityService.getAllSpecialities.and.returnValue(specUtil.simplePromise({data: specialities}));
-        ngDialog = jasmine.createSpyObj('ngDialog', ['close', 'openConfirm']);
-        state = jasmine.createSpyObj('$state', ['go']);
-        appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
-        appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
-        appService.getAppDescriptor.and.returnValue(appDescriptor);
-        colorsForAppointmentService = ['#000000', '#111111', '#ffffff'];
-        appDescriptor.getConfigValue.and.callFake(function (key) {
-            if (key === 'enableSpecialities') {
-                return true;
-            } else if (key === 'enableServiceTypes') {
-                return true;
-            } else if (key === 'colorsForAppointmentService') {
-                return colorsForAppointmentService;
-            } else if (key === 'enableCalendarView') {
-                return true;
-            } else if (key === 'enableAppointmentRequests') {
-                return true;
-            }
-        });
-        confirmBox = jasmine.createSpy('confirmBox');
-        appointmentCommonService = jasmine.createSpyObj('appointmentCommonService', ['hasPrivilege']);
+  beforeEach(function () {
+    appointmentsServiceService = jasmine.createSpyObj(
+      "appointmentsServiceService",
+      ["save", "getAllServices", "getAllNonVoidedAttributeTypes"],
+    );
+    appointmentsServiceService.save.and.returnValue(specUtil.simplePromise({}));
+    appointmentServices = [
+      { name: "Oncology", description: "Cancer treatment" },
+    ];
+    appointmentsServiceService.getAllServices.and.returnValue(
+      specUtil.simplePromise({ data: appointmentServices }),
+    );
+    var attributeTypes = [
+      {
+        uuid: "attr-type-1",
+        name: "Color Code",
+        datatype: "org.openmrs.customdatatype.datatype.FreeTextDatatype",
+        minOccurs: 0,
+        maxOccurs: 1,
+      },
+    ];
+    appointmentsServiceService.getAllNonVoidedAttributeTypes.and.returnValue(
+      specUtil.simplePromise({ data: attributeTypes }),
+    );
+    locationService = jasmine.createSpyObj("locationService", ["getAllByTag"]);
+    locations = [
+      { display: "OPD1", uuid: 1 },
+      { display: "Registration", uuid: 2 },
+    ];
+    locationService.getAllByTag.and.returnValue(
+      specUtil.simplePromise({ data: { results: locations } }),
+    );
+    messagingService = jasmine.createSpyObj("messagingService", [
+      "showMessage",
+    ]);
+    messagingService.showMessage.and.returnValue({});
+    specialityService = jasmine.createSpyObj("specialityService", [
+      "getAllSpecialities",
+    ]);
+    specialities = [
+      { name: "Cardiology", uuid: "81da9590-3f10-11e4-2908-0800271c1b75" },
+    ];
+    specialityService.getAllSpecialities.and.returnValue(
+      specUtil.simplePromise({ data: specialities }),
+    );
+    ngDialog = jasmine.createSpyObj("ngDialog", ["close", "openConfirm"]);
+    state = jasmine.createSpyObj("$state", ["go"]);
+    appService = jasmine.createSpyObj("appService", ["getAppDescriptor"]);
+    appDescriptor = jasmine.createSpyObj("appDescriptor", ["getConfigValue"]);
+    appService.getAppDescriptor.and.returnValue(appDescriptor);
+    colorsForAppointmentService = ["#000000", "#111111", "#ffffff"];
+    appDescriptor.getConfigValue.and.callFake(function (key) {
+      if (key === "enableSpecialities") {
+        return true;
+      } else if (key === "enableServiceTypes") {
+        return true;
+      } else if (key === "colorsForAppointmentService") {
+        return colorsForAppointmentService;
+      } else if (key === "enableCalendarView") {
+        return true;
+      } else if (key === "enableAppointmentRequests") {
+        return true;
+      }
     });
+    confirmBox = jasmine.createSpy("confirmBox");
+    appointmentCommonService = jasmine.createSpyObj(
+      "appointmentCommonService",
+      ["hasPrivilege"],
+    );
+  });
 
-    var createController = function () {
-        return controller('AppointmentServiceController', {
-            $scope: scope,
-            $q: q,
-            $state: state,
-            appointmentsServiceService: appointmentsServiceService,
-            locationService: locationService,
-            messagingService: messagingService,
-            specialityService: specialityService,
-            ngDialog: ngDialog,
-            appService: appService,
-            appointmentServiceContext: appointmentServiceContext,
-            confirmBox: confirmBox,
-            appointmentCommonService: appointmentCommonService
-        }
+  var createController = function () {
+    return controller("AppointmentServiceController", {
+      $scope: scope,
+      $q: q,
+      $state: state,
+      appointmentsServiceService: appointmentsServiceService,
+      locationService: locationService,
+      messagingService: messagingService,
+      specialityService: specialityService,
+      ngDialog: ngDialog,
+      appService: appService,
+      appointmentServiceContext: appointmentServiceContext,
+      confirmBox: confirmBox,
+      appointmentCommonService: appointmentCommonService,
+    });
+  };
+
+  describe("initialization", function () {
+    it("should fetch all appointment locations on initialization", function () {
+      expect(scope.locations).toBeUndefined();
+      createController();
+      expect(locationService.getAllByTag).toHaveBeenCalledWith(
+        "Appointment Location",
       );
-    };
-
-    describe('initialization', function () {
-        it('should fetch all appointment locations on initialization', function () {
-            expect(scope.locations).toBeUndefined();
-            createController();
-            expect(locationService.getAllByTag).toHaveBeenCalledWith('Appointment Location');
-            expect(scope.locations).toBe(locations);
-            expect(scope.enableSpecialities).toBeTruthy();
-            expect(scope.enableServiceTypes).toBeTruthy();
-            expect(scope.colorsForAppointmentService).toBe(colorsForAppointmentService);
-        });
-
-        it("should have default color for appointment service type", function () {
-            createController();
-            expect(scope.enableCalendarView).toBe(true);
-            expect(scope.service.color).toBe("#000000");
-            colorsForAppointmentService = undefined;
-            createController();
-            expect(scope.service.color).toBe("#008000");
-            scope.service.color = "#A9A9A9";
-            expect(scope.service.color).toBe("#A9A9A9");
-        });
-
-        it('should not fetch specialities if not configured', function () {
-            appDescriptor.getConfigValue.and.returnValue(false);
-            appService.getAppDescriptor.and.returnValue(appDescriptor);
-            expect(scope.specialities).toBeUndefined();
-            createController();
-            expect(specialityService.getAllSpecialities).not.toHaveBeenCalled();
-            expect(scope.specialities).toBeUndefined();
-        });
-
-        it('should fetch all specialities on initialization if configured', function () {
-            expect(scope.specialities).toBeUndefined();
-            createController();
-            expect(specialityService.getAllSpecialities).toHaveBeenCalled();
-            expect(scope.specialities).toBe(specialities);
-        });
-
-        it('should fetch all services on initialization', function () {
-            expect(scope.services).toBeUndefined();
-            createController();
-            expect(appointmentsServiceService.getAllServices).toHaveBeenCalled();
-            expect(scope.services).toBe(appointmentServices);
-        });
-
-        it('should fetch all attribute types on initialization', function () {
-            expect(scope.attributeTypes).toBeUndefined();
-            createController();
-            expect(appointmentsServiceService.getAllAttributeTypes).toHaveBeenCalled();
-            expect(scope.attributeTypes).toBeDefined();
-            expect(scope.attributeTypes.length).toBe(1);
-            expect(scope.attributeTypes[0].name).toBe('Color Code');
-        });
+      expect(scope.locations).toBe(locations);
+      expect(scope.enableSpecialities).toBeTruthy();
+      expect(scope.enableServiceTypes).toBeTruthy();
+      expect(scope.colorsForAppointmentService).toBe(
+        colorsForAppointmentService,
+      );
     });
 
-    describe('validateServiceName', function () {
-        var name;
-        beforeEach(function () {
-            createController();
-            name = jasmine.createSpyObj('name', ['$setValidity']);
-            scope.createServiceForm = {name: name};
-        });
-        it('should validate to true if service name is unique', function () {
-            scope.service = {name: 'Cardiology'};
-            scope.services = [{name: 'Endocrinology'}];
-            scope.validateServiceName();
-            expect(name.$setValidity).toHaveBeenCalledWith('uniqueServiceName', true);
-        });
-
-        it('should validate to false if service name is already exists', function () {
-            scope.service = {name: 'Cardiology'};
-            scope.services = [{name: 'Cardiology'}];
-            scope.validateServiceName();
-            expect(name.$setValidity).toHaveBeenCalledWith('uniqueServiceName', false);
-        });
-
-        it('should validate to false if case insensitive service name is exists', function () {
-            scope.service = {name: 'CArdIolOgy'};
-            scope.services = [{name: 'Cardiology'}];
-            scope.validateServiceName();
-            expect(name.$setValidity).toHaveBeenCalledWith('uniqueServiceName', false);
-        });
-
-        it('should validate to true if service name is empty', function () {
-            scope.service = {name: undefined};
-            scope.services = [{name: 'Endocrinology'}];
-            scope.validateServiceName();
-            expect(name.$setValidity).toHaveBeenCalledWith('uniqueServiceName', true);
-        });
-
-        it('should not compare with itself on edit', function () {
-            scope.service = {name: 'Cardiology', uuid: 'c36006e5-9fbb-4f20-866b-0ece245615a6'};
-            scope.services = [{name: 'Cardiology', uuid: 'c36006e5-9fbb-4f20-866b-0ece245615a6'}];
-            scope.validateServiceName();
-            expect(name.$setValidity).toHaveBeenCalledWith('uniqueServiceName', true);
-        })
+    it("should have default color for appointment service type", function () {
+      createController();
+      expect(scope.enableCalendarView).toBe(true);
+      expect(scope.service.color).toBe("#000000");
+      colorsForAppointmentService = undefined;
+      createController();
+      expect(scope.service.color).toBe("#008000");
+      scope.service.color = "#A9A9A9";
+      expect(scope.service.color).toBe("#A9A9A9");
     });
 
-    describe('save', function () {
-        var serviceTime, serviceMaxLoad;
-        beforeEach(function () {
-            createController();
-            scope.createServiceForm = {$invalid: false};
-            serviceTime = jasmine.createSpyObj('serviceTime', ['$setValidity']);
-            serviceTime.$invalid = false;
-            scope.createServiceForm.serviceTime = serviceTime;
-            serviceMaxLoad = jasmine.createSpyObj('serviceMaxLoad', ['$setValidity']);
-            serviceMaxLoad.$invalid = false;
-            scope.createServiceForm.serviceMaxLoad = serviceMaxLoad;
-        });
-
-        describe('clear incorrect data', function () {
-            var startDateTime, endDateTime, serviceResponse;
-            var dateUtil = Bahmni.Common.Util.DateUtil;
-            var timeFormat = 'HH:mm:ss';
-            beforeEach(function () {
-                startDateTime = new Date('1970-01-01T11:30:00.000Z');
-                endDateTime = new Date('1970-01-01T14:30:00.000Z');
-                serviceResponse = {
-                    startTime: dateUtil.getDateTimeInSpecifiedFormat(startDateTime, timeFormat),
-                    endTime: dateUtil.getDateTimeInSpecifiedFormat(endDateTime, timeFormat),
-                    maxAppointmentsLimit: -4
-                };
-                serviceTime.$invalid = true;
-                serviceMaxLoad.$invalid = true;
-            });
-
-            it('should clear incorrect service start and end time and maxLoad if at least one weeklyAvailability is added', function () {
-                serviceResponse.weeklyAvailability = [{startTime: new Date().toString(), endTime: new Date().toString(), dayOfWeek: 'SUNDAY'}];
-                scope.service = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceResponse);
-                scope.confirmSave();
-                expect(scope.service.startTime).toBeUndefined();
-                expect(scope.service.endTime).toBeUndefined();
-                expect(serviceTime.$setValidity).toHaveBeenCalledWith('timeSequence', true);
-                expect(scope.service.maxAppointmentsLimit).toBeUndefined();
-                expect(serviceMaxLoad.$setValidity).toHaveBeenCalledWith('min', true);
-            });
-
-            it('should clear service maxLoad if at least one service type is added', function () {
-                serviceResponse.serviceTypes = [{name: 'newType'}];
-                scope.service = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceResponse);
-                scope.confirmSave();
-                expect(scope.service.startTime.toString()).toEqual(startDateTime.toString());
-                expect(scope.service.endTime.toString()).toEqual(endDateTime.toString());
-                expect(serviceTime.$setValidity).not.toHaveBeenCalled();
-                expect(scope.service.maxAppointmentsLimit).toBeUndefined();
-                expect(serviceMaxLoad.$setValidity).toHaveBeenCalledWith('min', true);
-            });
-
-            it('should not clear service level incorrect start and end time and maxLoad if weeklyAvailability is empty', function () {
-                scope.service = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceResponse);
-                scope.confirmSave();
-                expect(scope.service.startTime.toString()).toEqual(startDateTime.toString());
-                expect(scope.service.endTime.toString()).toEqual(endDateTime.toString());
-                expect(serviceTime.$setValidity).not.toHaveBeenCalled();
-                expect(scope.service.maxAppointmentsLimit).toBe(-4);
-                expect(serviceMaxLoad.$setValidity).not.toHaveBeenCalled();
-            });
-
-            it('should not clear service maxLoad if no service type is added', function () {
-                scope.service = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceResponse);
-                scope.confirmSave();
-                expect(scope.service.startTime.toString()).toEqual(startDateTime.toString());
-                expect(scope.service.endTime.toString()).toEqual(endDateTime.toString());
-                expect(serviceTime.$setValidity).not.toHaveBeenCalled();
-                expect(scope.service.maxAppointmentsLimit).toBe(-4);
-                expect(serviceMaxLoad.$setValidity).not.toHaveBeenCalled();
-            });
-        });
-
-        it('should save all appointment service details', function () {
-            scope.service = {
-                name: 'Chemotherapy',
-                description: 'For cancer',
-                startTime: new Date().toString(),
-                endTime: new Date().toString(),
-                initialAppointmentStatus: 'Requested',
-                weeklyAvailability: [{
-                    startTime: new Date().toString(),
-                    endTime: new Date().toString(),
-                    days: [{name: 'MONDAY', isSelected: true}]
-                }]
-            };
-            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
-            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
-        });
-
-        it('should go to service list page after save', function () {
-            var startDateTime = new Date('Thu Jan 01 1970 09:45:00 GMT+0530 (IST)');
-            var endDateTime = new Date('Thu Jan 01 1970 18:30:00 GMT+0530 (IST)');
-            scope.service = {
-                name: 'Chemotherapy',
-                description: 'For cancer',
-                startTime: startDateTime,
-                endTime: endDateTime
-            };
-            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
-            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
-            expect(state.go).toHaveBeenCalledWith('home.admin.service');
-        });
-
-        it('should show error message if form is invalid', function () {
-            scope.createServiceForm.$invalid = true;
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
-            expect(messagingService.showMessage).toHaveBeenCalledWith('error', 'INVALID_SERVICE_FORM_ERROR_MESSAGE');
-            expect(state.go).not.toHaveBeenCalled();
-        });
-
-        it('should save all appointment service details only if confirmed on edit', function () {
-            confirmBox.and.callFake(function (config) {
-                config.scope.ok(function () {
-                });
-            });
-            scope.service = {
-                uuid: 'd4938f10-8677-4ad2-acd1-30a7ea21b810',
-                name: 'Chemotherapy'
-            };
-            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
-            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
-        });
-
-        it('should not call save if cancelled on edit', function () {
-            confirmBox.and.callFake(function (config) {
-                config.scope.cancel(function () {
-                });
-            });
-            scope.service = {
-                uuid: 'd4938f10-8677-4ad2-acd1-30a7ea21b810',
-                name: 'Chemotherapy'
-            };
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
-            expect(messagingService.showMessage).not.toHaveBeenCalled();
-        });
-
-        it('should validate required attributes before save', function () {
-            scope.attributeTypes = [
-                {
-                    uuid: 'attr-type-1',
-                    name: 'Priority',
-                    minOccurs: 1,
-                    maxOccurs: 1
-                }
-            ];
-            scope.service = {
-                name: 'Chemotherapy',
-                attributes: []
-            };
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
-            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided");
-        });
-
-        it('should save when required attributes are provided', function () {
-            scope.attributeTypes = [
-                {
-                    uuid: 'attr-type-1',
-                    name: 'Priority',
-                    minOccurs: 1,
-                    maxOccurs: 1
-                }
-            ];
-            scope.service = {
-                name: 'Chemotherapy',
-                attributes: [
-                    {
-                        attributeTypeUuid: 'attr-type-1',
-                        value: 'High',
-                        voided: false
-                    }
-                ]
-            };
-            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
-            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
-        });
-
-        it('should prevent save when maxOccurs is exceeded', function () {
-            scope.attributeTypes = [
-                {
-                    uuid: 'attr-type-1',
-                    name: 'Color Code',
-                    minOccurs: 0,
-                    maxOccurs: 1
-                }
-            ];
-            scope.service = {
-                name: 'Chemotherapy',
-                attributes: [
-                    {
-                        attributeTypeUuid: 'attr-type-1',
-                        value: 'Red',
-                        voided: false
-                    },
-                    {
-                        attributeTypeUuid: 'attr-type-1',
-                        value: 'Blue',
-                        voided: false
-                    }
-                ]
-            };
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
-            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Color Code' allows maximum 1 occurrence(s), but 2 provided");
-        });
-
-        it('should save when no attribute types are configured', function () {
-            scope.attributeTypes = [];
-            scope.service = {
-                name: 'Chemotherapy'
-            };
-            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
-            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
-        });
-
-        it('should ignore voided attributes in validation', function () {
-            scope.attributeTypes = [
-                {
-                    uuid: 'attr-type-1',
-                    name: 'Priority',
-                    minOccurs: 1,
-                    maxOccurs: 1
-                }
-            ];
-            scope.service = {
-                name: 'Chemotherapy',
-                attributes: [
-                    {
-                        uuid: 'attr-uuid-1',
-                        attributeTypeUuid: 'attr-type-1',
-                        value: 'High',
-                        voided: true
-                    }
-                ]
-            };
-            scope.confirmSave();
-            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
-            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided");
-        });
+    it("should not fetch specialities if not configured", function () {
+      appDescriptor.getConfigValue.and.returnValue(false);
+      appService.getAppDescriptor.and.returnValue(appDescriptor);
+      expect(scope.specialities).toBeUndefined();
+      createController();
+      expect(specialityService.getAllSpecialities).not.toHaveBeenCalled();
+      expect(scope.specialities).toBeUndefined();
     });
 
-    describe('confirmationDialogOnStateChange', function () {
-        beforeEach(function () {
-            state.name = 'home.service';
-            createController();
-        });
-
-        it('should open confirmation dialog if we change the state', function () {
-            scope.$broadcast("$stateChangeStart");
-
-            let args = ngDialog.openConfirm.calls.allArgs()[0][0];
-            expect(args.plain).toBeTruthy();
-            expect(args.template).toContain("<p>{{'NAVIGATION_CONFIRMATION_DIALOG_MESSAGE_KEY' | translate}}</p>");
-            expect(args.scope).toEqual(scope);
-            expect(args.closeByEscape).toBeTruthy();
-        });
-
-        it('should stay in current state if Cancel is selected', function () {
-            expect(state.name).toEqual('home.service');
-            scope.cancelTransition();
-            expect(state.name).toEqual('home.service');
-            expect(ngDialog.close).toHaveBeenCalled();
-        });
-
-        it("should not save and go to target state if Don't save is selected", function () {
-            var toState = {name: "home.manage"};
-            var toParams = {config: 'default'};
-            expect(state.name).toEqual("home.service");
-            scope.save = jasmine.createSpy('save');
-            scope.toStateConfig = {toState: toState, toParams: toParams};
-            scope.continueWithoutSaving();
-            expect(state.go).toHaveBeenCalledWith(toState, toParams);
-            expect(ngDialog.close).toHaveBeenCalled();
-        });
+    it("should fetch all specialities on initialization if configured", function () {
+      expect(scope.specialities).toBeUndefined();
+      createController();
+      expect(specialityService.getAllSpecialities).toHaveBeenCalled();
+      expect(scope.specialities).toBe(specialities);
     });
+
+    it("should fetch all services on initialization", function () {
+      expect(scope.services).toBeUndefined();
+      createController();
+      expect(appointmentsServiceService.getAllServices).toHaveBeenCalled();
+      expect(scope.services).toBe(appointmentServices);
+    });
+
+    it("should fetch all attribute types on initialization", function () {
+      expect(scope.attributeTypes).toBeUndefined();
+      createController();
+      expect(
+        appointmentsServiceService.getAllNonVoidedAttributeTypes,
+      ).toHaveBeenCalled();
+      expect(scope.attributeTypes).toBeDefined();
+      expect(scope.attributeTypes.length).toBe(1);
+      expect(scope.attributeTypes[0].name).toBe("Color Code");
+    });
+  });
+
+  describe("validateServiceName", function () {
+    var name;
+    beforeEach(function () {
+      createController();
+      name = jasmine.createSpyObj("name", ["$setValidity"]);
+      scope.createServiceForm = { name: name };
+    });
+    it("should validate to true if service name is unique", function () {
+      scope.service = { name: "Cardiology" };
+      scope.services = [{ name: "Endocrinology" }];
+      scope.validateServiceName();
+      expect(name.$setValidity).toHaveBeenCalledWith("uniqueServiceName", true);
+    });
+
+    it("should validate to false if service name is already exists", function () {
+      scope.service = { name: "Cardiology" };
+      scope.services = [{ name: "Cardiology" }];
+      scope.validateServiceName();
+      expect(name.$setValidity).toHaveBeenCalledWith(
+        "uniqueServiceName",
+        false,
+      );
+    });
+
+    it("should validate to false if case insensitive service name is exists", function () {
+      scope.service = { name: "CArdIolOgy" };
+      scope.services = [{ name: "Cardiology" }];
+      scope.validateServiceName();
+      expect(name.$setValidity).toHaveBeenCalledWith(
+        "uniqueServiceName",
+        false,
+      );
+    });
+
+    it("should validate to true if service name is empty", function () {
+      scope.service = { name: undefined };
+      scope.services = [{ name: "Endocrinology" }];
+      scope.validateServiceName();
+      expect(name.$setValidity).toHaveBeenCalledWith("uniqueServiceName", true);
+    });
+
+    it("should not compare with itself on edit", function () {
+      scope.service = {
+        name: "Cardiology",
+        uuid: "c36006e5-9fbb-4f20-866b-0ece245615a6",
+      };
+      scope.services = [
+        { name: "Cardiology", uuid: "c36006e5-9fbb-4f20-866b-0ece245615a6" },
+      ];
+      scope.validateServiceName();
+      expect(name.$setValidity).toHaveBeenCalledWith("uniqueServiceName", true);
+    });
+  });
+
+  describe("save", function () {
+    var serviceTime, serviceMaxLoad;
+    beforeEach(function () {
+      createController();
+      scope.createServiceForm = { $invalid: false };
+      serviceTime = jasmine.createSpyObj("serviceTime", ["$setValidity"]);
+      serviceTime.$invalid = false;
+      scope.createServiceForm.serviceTime = serviceTime;
+      serviceMaxLoad = jasmine.createSpyObj("serviceMaxLoad", ["$setValidity"]);
+      serviceMaxLoad.$invalid = false;
+      scope.createServiceForm.serviceMaxLoad = serviceMaxLoad;
+    });
+
+    describe("clear incorrect data", function () {
+      var startDateTime, endDateTime, serviceResponse;
+      var dateUtil = Bahmni.Common.Util.DateUtil;
+      var timeFormat = "HH:mm:ss";
+      beforeEach(function () {
+        startDateTime = new Date("1970-01-01T11:30:00.000Z");
+        endDateTime = new Date("1970-01-01T14:30:00.000Z");
+        serviceResponse = {
+          startTime: dateUtil.getDateTimeInSpecifiedFormat(
+            startDateTime,
+            timeFormat,
+          ),
+          endTime: dateUtil.getDateTimeInSpecifiedFormat(
+            endDateTime,
+            timeFormat,
+          ),
+          maxAppointmentsLimit: -4,
+        };
+        serviceTime.$invalid = true;
+        serviceMaxLoad.$invalid = true;
+      });
+
+      it("should clear incorrect service start and end time and maxLoad if at least one weeklyAvailability is added", function () {
+        serviceResponse.weeklyAvailability = [
+          {
+            startTime: new Date().toString(),
+            endTime: new Date().toString(),
+            dayOfWeek: "SUNDAY",
+          },
+        ];
+        scope.service =
+          Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(
+            serviceResponse,
+          );
+        scope.confirmSave();
+        expect(scope.service.startTime).toBeUndefined();
+        expect(scope.service.endTime).toBeUndefined();
+        expect(serviceTime.$setValidity).toHaveBeenCalledWith(
+          "timeSequence",
+          true,
+        );
+        expect(scope.service.maxAppointmentsLimit).toBeUndefined();
+        expect(serviceMaxLoad.$setValidity).toHaveBeenCalledWith("min", true);
+      });
+
+      it("should clear service maxLoad if at least one service type is added", function () {
+        serviceResponse.serviceTypes = [{ name: "newType" }];
+        scope.service =
+          Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(
+            serviceResponse,
+          );
+        scope.confirmSave();
+        expect(scope.service.startTime.toString()).toEqual(
+          startDateTime.toString(),
+        );
+        expect(scope.service.endTime.toString()).toEqual(
+          endDateTime.toString(),
+        );
+        expect(serviceTime.$setValidity).not.toHaveBeenCalled();
+        expect(scope.service.maxAppointmentsLimit).toBeUndefined();
+        expect(serviceMaxLoad.$setValidity).toHaveBeenCalledWith("min", true);
+      });
+
+      it("should not clear service level incorrect start and end time and maxLoad if weeklyAvailability is empty", function () {
+        scope.service =
+          Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(
+            serviceResponse,
+          );
+        scope.confirmSave();
+        expect(scope.service.startTime.toString()).toEqual(
+          startDateTime.toString(),
+        );
+        expect(scope.service.endTime.toString()).toEqual(
+          endDateTime.toString(),
+        );
+        expect(serviceTime.$setValidity).not.toHaveBeenCalled();
+        expect(scope.service.maxAppointmentsLimit).toBe(-4);
+        expect(serviceMaxLoad.$setValidity).not.toHaveBeenCalled();
+      });
+
+      it("should not clear service maxLoad if no service type is added", function () {
+        scope.service =
+          Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(
+            serviceResponse,
+          );
+        scope.confirmSave();
+        expect(scope.service.startTime.toString()).toEqual(
+          startDateTime.toString(),
+        );
+        expect(scope.service.endTime.toString()).toEqual(
+          endDateTime.toString(),
+        );
+        expect(serviceTime.$setValidity).not.toHaveBeenCalled();
+        expect(scope.service.maxAppointmentsLimit).toBe(-4);
+        expect(serviceMaxLoad.$setValidity).not.toHaveBeenCalled();
+      });
+    });
+
+    it("should save all appointment service details", function () {
+      scope.service = {
+        name: "Chemotherapy",
+        description: "For cancer",
+        startTime: new Date().toString(),
+        endTime: new Date().toString(),
+        initialAppointmentStatus: "Requested",
+        weeklyAvailability: [
+          {
+            startTime: new Date().toString(),
+            endTime: new Date().toString(),
+            days: [{ name: "MONDAY", isSelected: true }],
+          },
+        ],
+      };
+      var service = Bahmni.Appointments.AppointmentService.createFromUIObject(
+        scope.service,
+      );
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "info",
+        "APPOINTMENT_SERVICE_SAVE_SUCCESS",
+      );
+    });
+
+    it("should go to service list page after save", function () {
+      var startDateTime = new Date("Thu Jan 01 1970 09:45:00 GMT+0530 (IST)");
+      var endDateTime = new Date("Thu Jan 01 1970 18:30:00 GMT+0530 (IST)");
+      scope.service = {
+        name: "Chemotherapy",
+        description: "For cancer",
+        startTime: startDateTime,
+        endTime: endDateTime,
+      };
+      var service = Bahmni.Appointments.AppointmentService.createFromUIObject(
+        scope.service,
+      );
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "info",
+        "APPOINTMENT_SERVICE_SAVE_SUCCESS",
+      );
+      expect(state.go).toHaveBeenCalledWith("home.admin.service");
+    });
+
+    it("should show error message if form is invalid", function () {
+      scope.createServiceForm.$invalid = true;
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "error",
+        "INVALID_SERVICE_FORM_ERROR_MESSAGE",
+      );
+      expect(state.go).not.toHaveBeenCalled();
+    });
+
+    it("should save all appointment service details only if confirmed on edit", function () {
+      confirmBox.and.callFake(function (config) {
+        config.scope.ok(function () {});
+      });
+      scope.service = {
+        uuid: "d4938f10-8677-4ad2-acd1-30a7ea21b810",
+        name: "Chemotherapy",
+      };
+      var service = Bahmni.Appointments.AppointmentService.createFromUIObject(
+        scope.service,
+      );
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "info",
+        "APPOINTMENT_SERVICE_SAVE_SUCCESS",
+      );
+    });
+
+    it("should not call save if cancelled on edit", function () {
+      confirmBox.and.callFake(function (config) {
+        config.scope.cancel(function () {});
+      });
+      scope.service = {
+        uuid: "d4938f10-8677-4ad2-acd1-30a7ea21b810",
+        name: "Chemotherapy",
+      };
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+      expect(messagingService.showMessage).not.toHaveBeenCalled();
+    });
+
+    it("should validate required attributes before save", function () {
+      scope.attributeTypes = [
+        {
+          uuid: "attr-type-1",
+          name: "Priority",
+          minOccurs: 1,
+          maxOccurs: 1,
+        },
+      ];
+      scope.service = {
+        name: "Chemotherapy",
+        attributes: [],
+      };
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "error",
+        "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided",
+      );
+    });
+
+    it("should save when required attributes are provided", function () {
+      scope.attributeTypes = [
+        {
+          uuid: "attr-type-1",
+          name: "Priority",
+          minOccurs: 1,
+          maxOccurs: 1,
+        },
+      ];
+      scope.service = {
+        name: "Chemotherapy",
+        attributes: [
+          {
+            attributeTypeUuid: "attr-type-1",
+            value: "High",
+            voided: false,
+          },
+        ],
+      };
+      var service = Bahmni.Appointments.AppointmentService.createFromUIObject(
+        scope.service,
+      );
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "info",
+        "APPOINTMENT_SERVICE_SAVE_SUCCESS",
+      );
+    });
+
+    it("should prevent save when maxOccurs is exceeded", function () {
+      scope.attributeTypes = [
+        {
+          uuid: "attr-type-1",
+          name: "Color Code",
+          minOccurs: 0,
+          maxOccurs: 1,
+        },
+      ];
+      scope.service = {
+        name: "Chemotherapy",
+        attributes: [
+          {
+            attributeTypeUuid: "attr-type-1",
+            value: "Red",
+            voided: false,
+          },
+          {
+            attributeTypeUuid: "attr-type-1",
+            value: "Blue",
+            voided: false,
+          },
+        ],
+      };
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "error",
+        "Attribute 'Color Code' allows maximum 1 occurrence(s), but 2 provided",
+      );
+    });
+
+    it("should save when no attribute types are configured", function () {
+      scope.attributeTypes = [];
+      scope.service = {
+        name: "Chemotherapy",
+      };
+      var service = Bahmni.Appointments.AppointmentService.createFromUIObject(
+        scope.service,
+      );
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "info",
+        "APPOINTMENT_SERVICE_SAVE_SUCCESS",
+      );
+    });
+
+    it("should ignore voided attributes in validation", function () {
+      scope.attributeTypes = [
+        {
+          uuid: "attr-type-1",
+          name: "Priority",
+          minOccurs: 1,
+          maxOccurs: 1,
+        },
+      ];
+      scope.service = {
+        name: "Chemotherapy",
+        attributes: [
+          {
+            uuid: "attr-uuid-1",
+            attributeTypeUuid: "attr-type-1",
+            value: "High",
+            voided: true,
+          },
+        ],
+      };
+      scope.confirmSave();
+      expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+      expect(messagingService.showMessage).toHaveBeenCalledWith(
+        "error",
+        "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided",
+      );
+    });
+  });
+
+  describe("confirmationDialogOnStateChange", function () {
+    beforeEach(function () {
+      state.name = "home.service";
+      createController();
+    });
+
+    it("should open confirmation dialog if we change the state", function () {
+      scope.$broadcast("$stateChangeStart");
+
+      let args = ngDialog.openConfirm.calls.allArgs()[0][0];
+      expect(args.plain).toBeTruthy();
+      expect(args.template).toContain(
+        "<p>{{'NAVIGATION_CONFIRMATION_DIALOG_MESSAGE_KEY' | translate}}</p>",
+      );
+      expect(args.scope).toEqual(scope);
+      expect(args.closeByEscape).toBeTruthy();
+    });
+
+    it("should stay in current state if Cancel is selected", function () {
+      expect(state.name).toEqual("home.service");
+      scope.cancelTransition();
+      expect(state.name).toEqual("home.service");
+      expect(ngDialog.close).toHaveBeenCalled();
+    });
+
+    it("should not save and go to target state if Don't save is selected", function () {
+      var toState = { name: "home.manage" };
+      var toParams = { config: "default" };
+      expect(state.name).toEqual("home.service");
+      scope.save = jasmine.createSpy("save");
+      scope.toStateConfig = { toState: toState, toParams: toParams };
+      scope.continueWithoutSaving();
+      expect(state.go).toHaveBeenCalledWith(toState, toParams);
+      expect(ngDialog.close).toHaveBeenCalled();
+    });
+  });
 });

--- a/test/controllers/admin/appointmentServiceController.spec.js
+++ b/test/controllers/admin/appointmentServiceController.spec.js
@@ -15,10 +15,14 @@ describe("AppointmentServiceController", function () {
     });
 
     beforeEach(function () {
-        appointmentsServiceService = jasmine.createSpyObj('appointmentsServiceService', ['save', 'getAllServices']);
+        appointmentsServiceService = jasmine.createSpyObj('appointmentsServiceService', ['save', 'getAllServices', 'getAllAttributeTypes']);
         appointmentsServiceService.save.and.returnValue(specUtil.simplePromise({}));
         appointmentServices = [{name: "Oncology", description: "Cancer treatment"}];
         appointmentsServiceService.getAllServices.and.returnValue(specUtil.simplePromise({data: appointmentServices}));
+        var attributeTypes = [
+            {uuid: 'attr-type-1', name: 'Color Code', datatype: 'org.openmrs.customdatatype.datatype.FreeTextDatatype', minOccurs: 0, maxOccurs: 1}
+        ];
+        appointmentsServiceService.getAllAttributeTypes.and.returnValue(specUtil.simplePromise({data: attributeTypes}));
         locationService = jasmine.createSpyObj('locationService', ['getAllByTag']);
         locations = [
             {display: "OPD1", uuid: 1},
@@ -114,6 +118,15 @@ describe("AppointmentServiceController", function () {
             createController();
             expect(appointmentsServiceService.getAllServices).toHaveBeenCalled();
             expect(scope.services).toBe(appointmentServices);
+        });
+
+        it('should fetch all attribute types on initialization', function () {
+            expect(scope.attributeTypes).toBeUndefined();
+            createController();
+            expect(appointmentsServiceService.getAllAttributeTypes).toHaveBeenCalled();
+            expect(scope.attributeTypes).toBeDefined();
+            expect(scope.attributeTypes.length).toBe(1);
+            expect(scope.attributeTypes[0].name).toBe('Color Code');
         });
     });
 

--- a/test/controllers/admin/appointmentServiceController.spec.js
+++ b/test/controllers/admin/appointmentServiceController.spec.js
@@ -316,6 +316,114 @@ describe("AppointmentServiceController", function () {
             expect(appointmentsServiceService.save).not.toHaveBeenCalled();
             expect(messagingService.showMessage).not.toHaveBeenCalled();
         });
+
+        it('should validate required attributes before save', function () {
+            scope.attributeTypes = [
+                {
+                    uuid: 'attr-type-1',
+                    name: 'Priority',
+                    minOccurs: 1,
+                    maxOccurs: 1
+                }
+            ];
+            scope.service = {
+                name: 'Chemotherapy',
+                attributes: []
+            };
+            scope.confirmSave();
+            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided");
+        });
+
+        it('should save when required attributes are provided', function () {
+            scope.attributeTypes = [
+                {
+                    uuid: 'attr-type-1',
+                    name: 'Priority',
+                    minOccurs: 1,
+                    maxOccurs: 1
+                }
+            ];
+            scope.service = {
+                name: 'Chemotherapy',
+                attributes: [
+                    {
+                        attributeTypeUuid: 'attr-type-1',
+                        value: 'High',
+                        voided: false
+                    }
+                ]
+            };
+            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
+            scope.confirmSave();
+            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
+        });
+
+        it('should prevent save when maxOccurs is exceeded', function () {
+            scope.attributeTypes = [
+                {
+                    uuid: 'attr-type-1',
+                    name: 'Color Code',
+                    minOccurs: 0,
+                    maxOccurs: 1
+                }
+            ];
+            scope.service = {
+                name: 'Chemotherapy',
+                attributes: [
+                    {
+                        attributeTypeUuid: 'attr-type-1',
+                        value: 'Red',
+                        voided: false
+                    },
+                    {
+                        attributeTypeUuid: 'attr-type-1',
+                        value: 'Blue',
+                        voided: false
+                    }
+                ]
+            };
+            scope.confirmSave();
+            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Color Code' allows maximum 1 occurrence(s), but 2 provided");
+        });
+
+        it('should save when no attribute types are configured', function () {
+            scope.attributeTypes = [];
+            scope.service = {
+                name: 'Chemotherapy'
+            };
+            var service = Bahmni.Appointments.AppointmentService.createFromUIObject(scope.service);
+            scope.confirmSave();
+            expect(appointmentsServiceService.save).toHaveBeenCalledWith(service);
+            expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'APPOINTMENT_SERVICE_SAVE_SUCCESS');
+        });
+
+        it('should ignore voided attributes in validation', function () {
+            scope.attributeTypes = [
+                {
+                    uuid: 'attr-type-1',
+                    name: 'Priority',
+                    minOccurs: 1,
+                    maxOccurs: 1
+                }
+            ];
+            scope.service = {
+                name: 'Chemotherapy',
+                attributes: [
+                    {
+                        uuid: 'attr-uuid-1',
+                        attributeTypeUuid: 'attr-type-1',
+                        value: 'High',
+                        voided: true
+                    }
+                ]
+            };
+            scope.confirmSave();
+            expect(appointmentsServiceService.save).not.toHaveBeenCalled();
+            expect(messagingService.showMessage).toHaveBeenCalledWith('error', "Attribute 'Priority' requires at least 1 occurrence(s), but only 0 provided");
+        });
     });
 
     describe('confirmationDialogOnStateChange', function () {

--- a/test/directives/serviceAttributes.spec.js
+++ b/test/directives/serviceAttributes.spec.js
@@ -1,0 +1,168 @@
+'use strict';
+
+describe('ServiceAttributes', function () {
+    var compile, scope, httpBackend, ngDialog, messagingService;
+
+    beforeEach(module('bahmni.appointments', function ($provide) {
+        ngDialog = jasmine.createSpyObj('ngDialog', ['openConfirm', 'close']);
+        messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
+        $provide.value('ngDialog', ngDialog);
+        $provide.value('messagingService', messagingService);
+    }));
+
+    beforeEach(inject(function ($compile, $httpBackend, $rootScope) {
+        compile = $compile;
+        scope = $rootScope.$new();
+        httpBackend = $httpBackend;
+        httpBackend.expectGET('./i18n/appointments/locale_en.json').respond({});
+        httpBackend.expectGET('/bahmni_config/openmrs/i18n/appointments/locale_en.json').respond({});
+
+        scope.service = {
+            name: 'Ortho',
+            description: 'for Ortho appointments',
+            attributes: []
+        };
+
+        scope.attributeTypes = [
+            {
+                uuid: 'attr-type-1',
+                name: 'Color Code',
+                description: 'Color code for the service',
+                datatype: 'org.openmrs.customdatatype.datatype.FreeTextDatatype',
+                minOccurs: 0,
+                maxOccurs: 1
+            },
+            {
+                uuid: 'attr-type-2',
+                name: 'Priority',
+                description: 'Priority level',
+                datatype: 'org.openmrs.customdatatype.datatype.FreeTextDatatype',
+                minOccurs: 1,
+                maxOccurs: 1
+            }
+        ];
+
+        var element = createElement();
+        scope = element.isolateScope();
+    }));
+
+    var createElement = function () {
+        var html = '<service-attributes service="service" attribute-types="attributeTypes"></service-attributes>';
+        var element = compile(angular.element(html))(scope);
+        scope.$digest();
+        httpBackend.flush();
+        return element;
+    };
+
+    it("should initialize attributes from service", function () {
+        expect(scope.service.attributes).toBeDefined();
+        expect(scope.service.attributes.length).toBe(0);
+    });
+
+    it("should add attribute value", function () {
+        scope.addOrUpdateAttribute('attr-type-1', 'Color Code', '#FF5733');
+
+        expect(scope.service.attributes.length).toBe(1);
+        expect(scope.service.attributes[0].attributeTypeUuid).toBe('attr-type-1');
+        expect(scope.service.attributes[0].value).toBe('#FF5733');
+    });
+
+    it("should update existing attribute value", function () {
+        scope.service.attributes = [{
+            uuid: 'attr-uuid-1',
+            attributeTypeUuid: 'attr-type-1',
+            value: '#FF5733',
+            voided: false
+        }];
+
+        scope.addOrUpdateAttribute('attr-type-1', 'Color Code', '#00FF00');
+
+        expect(scope.service.attributes.length).toBe(1);
+        expect(scope.service.attributes[0].value).toBe('#00FF00');
+        expect(scope.service.attributes[0].uuid).toBe('attr-uuid-1');
+    });
+
+    it("should remove attribute when value is cleared", function () {
+        scope.service.attributes = [{
+            uuid: 'attr-uuid-1',
+            attributeTypeUuid: 'attr-type-1',
+            value: '#FF5733',
+            voided: false
+        }];
+
+        scope.removeAttribute('attr-type-1');
+
+        // The attribute should be marked as voided, not removed
+        var nonVoidedAttrs = scope.service.attributes.filter(function(attr) {
+            return !attr.voided;
+        });
+        expect(nonVoidedAttrs.length).toBe(0);
+        expect(scope.service.attributes.length).toBe(1);
+        expect(scope.service.attributes[0].voided).toBe(true);
+    });
+
+    it("should void existing saved attribute when removed", function () {
+        scope.service.attributes = [{
+            uuid: 'attr-uuid-1',
+            attributeTypeUuid: 'attr-type-1',
+            value: '#FF5733',
+            voided: false
+        }];
+
+        scope.removeAttribute('attr-type-1');
+
+        var voidedAttr = scope.service.attributes.find(function(attr) {
+            return attr.uuid === 'attr-uuid-1';
+        });
+
+        // The attribute should be marked as voided rather than removed
+        expect(voidedAttr).toBeDefined();
+        expect(voidedAttr.voided).toBeTruthy();
+    });
+
+    it("should get attribute value by type uuid", function () {
+        scope.service.attributes = [{
+            attributeTypeUuid: 'attr-type-1',
+            value: '#FF5733',
+            voided: false
+        }];
+
+        // Re-initialize attributeValues after modifying service.attributes
+        scope.attributeValues = {};
+        scope.service.attributes.forEach(function (attr) {
+            if (!attr.voided) {
+                scope.attributeValues[attr.attributeTypeUuid] = attr.value;
+            }
+        });
+
+        var value = scope.getAttributeValue('attr-type-1');
+
+        expect(value).toBe('#FF5733');
+    });
+
+    it("should return empty string if attribute not found", function () {
+        var value = scope.getAttributeValue('non-existent');
+
+        expect(value).toBe('');
+    });
+
+    it("should validate required attributes", function () {
+        // Priority is required (minOccurs: 1)
+        var isValid = scope.validateAttributes();
+
+        expect(isValid).toBe(false);
+        expect(messagingService.showMessage).toHaveBeenCalledWith('error', jasmine.any(String));
+    });
+
+    it("should pass validation when all required attributes are present", function () {
+        scope.service.attributes = [{
+            attributeTypeUuid: 'attr-type-2',
+            value: 'High'
+        }];
+
+        var isValid = scope.validateAttributes();
+
+        expect(isValid).toBe(true);
+        expect(messagingService.showMessage).not.toHaveBeenCalled();
+    });
+});

--- a/test/directives/serviceAttributes.spec.js
+++ b/test/directives/serviceAttributes.spec.js
@@ -1,11 +1,15 @@
 'use strict';
 
 describe('ServiceAttributes', function () {
-    var compile, scope, httpBackend, ngDialog;
+    var compile, scope, httpBackend, ngDialog, appointmentCommonService;
 
     beforeEach(module('bahmni.appointments', function ($provide) {
         ngDialog = jasmine.createSpyObj('ngDialog', ['openConfirm', 'close']);
+        appointmentCommonService = jasmine.createSpyObj('appointmentCommonService', ['hasPrivilege']);
+        appointmentCommonService.hasPrivilege.and.returnValue(true);
+
         $provide.value('ngDialog', ngDialog);
+        $provide.value('appointmentCommonService', appointmentCommonService);
     }));
 
     beforeEach(inject(function ($compile, $httpBackend, $rootScope) {

--- a/test/directives/serviceAttributes.spec.js
+++ b/test/directives/serviceAttributes.spec.js
@@ -1,13 +1,11 @@
 'use strict';
 
 describe('ServiceAttributes', function () {
-    var compile, scope, httpBackend, ngDialog, messagingService;
+    var compile, scope, httpBackend, ngDialog;
 
     beforeEach(module('bahmni.appointments', function ($provide) {
         ngDialog = jasmine.createSpyObj('ngDialog', ['openConfirm', 'close']);
-        messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
         $provide.value('ngDialog', ngDialog);
-        $provide.value('messagingService', messagingService);
     }));
 
     beforeEach(inject(function ($compile, $httpBackend, $rootScope) {
@@ -144,25 +142,5 @@ describe('ServiceAttributes', function () {
         var value = scope.getAttributeValue('non-existent');
 
         expect(value).toBe('');
-    });
-
-    it("should validate required attributes", function () {
-        // Priority is required (minOccurs: 1)
-        var isValid = scope.validateAttributes();
-
-        expect(isValid).toBe(false);
-        expect(messagingService.showMessage).toHaveBeenCalledWith('error', jasmine.any(String));
-    });
-
-    it("should pass validation when all required attributes are present", function () {
-        scope.service.attributes = [{
-            attributeTypeUuid: 'attr-type-2',
-            value: 'High'
-        }];
-
-        var isValid = scope.validateAttributes();
-
-        expect(isValid).toBe(true);
-        expect(messagingService.showMessage).not.toHaveBeenCalled();
     });
 });

--- a/test/directives/serviceAttributes.spec.js
+++ b/test/directives/serviceAttributes.spec.js
@@ -90,7 +90,6 @@ describe('ServiceAttributes', function () {
 
         scope.removeAttribute('attr-type-1');
 
-        // The attribute should be marked as voided, not removed
         var nonVoidedAttrs = scope.service.attributes.filter(function(attr) {
             return !attr.voided;
         });
@@ -113,7 +112,6 @@ describe('ServiceAttributes', function () {
             return attr.uuid === 'attr-uuid-1';
         });
 
-        // The attribute should be marked as voided rather than removed
         expect(voidedAttr).toBeDefined();
         expect(voidedAttr.voided).toBeTruthy();
     });
@@ -125,7 +123,6 @@ describe('ServiceAttributes', function () {
             voided: false
         }];
 
-        // Re-initialize attributeValues after modifying service.attributes
         scope.attributeValues = {};
         scope.service.attributes.forEach(function (attr) {
             if (!attr.voided) {

--- a/test/models/AppointmentServiceViewModel.spec.js
+++ b/test/models/AppointmentServiceViewModel.spec.js
@@ -92,4 +92,78 @@ describe('AppointmentServiceViewModel', function () {
         expect(availability3.days[5].isSelected).toBeTruthy();
         expect(availability3.days[5].uuid).toBe(serviceResponse.weeklyAvailability[3].uuid);
     });
+
+    it('should parse attributes from response', function () {
+        var serviceWithAttributes = angular.extend({}, serviceResponse, {
+            attributes: [
+                {
+                    uuid: 'attr-uuid-1',
+                    attributeType: 'Color Code',
+                    attributeTypeUuid: 'attr-type-uuid-1',
+                    value: '#FF5733',
+                    voided: false
+                },
+                {
+                    uuid: 'attr-uuid-2',
+                    attributeType: 'Priority',
+                    attributeTypeUuid: 'attr-type-uuid-2',
+                    value: 'High',
+                    voided: false
+                }
+            ]
+        });
+
+        var viewModel = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceWithAttributes);
+
+        expect(viewModel.attributes).toBeDefined();
+        expect(viewModel.attributes.length).toBe(2);
+        expect(viewModel.attributes[0].uuid).toBe('attr-uuid-1');
+        expect(viewModel.attributes[0].attributeTypeUuid).toBe('attr-type-uuid-1');
+        expect(viewModel.attributes[0].value).toBe('#FF5733');
+    });
+
+    it('should filter out voided attributes', function () {
+        var serviceWithAttributes = angular.extend({}, serviceResponse, {
+            attributes: [
+                {
+                    uuid: 'attr-uuid-1',
+                    attributeType: 'Color Code',
+                    attributeTypeUuid: 'attr-type-uuid-1',
+                    value: '#FF5733',
+                    voided: false
+                },
+                {
+                    uuid: 'attr-uuid-2',
+                    attributeType: 'Priority',
+                    attributeTypeUuid: 'attr-type-uuid-2',
+                    value: 'High',
+                    voided: true
+                }
+            ]
+        });
+
+        var viewModel = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceWithAttributes);
+
+        expect(viewModel.attributes).toBeDefined();
+        expect(viewModel.attributes.length).toBe(1);
+        expect(viewModel.attributes[0].uuid).toBe('attr-uuid-1');
+    });
+
+    it('should handle empty attributes', function () {
+        var serviceWithAttributes = angular.extend({}, serviceResponse, {
+            attributes: []
+        });
+
+        var viewModel = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceWithAttributes);
+
+        expect(viewModel.attributes).toBeDefined();
+        expect(viewModel.attributes.length).toBe(0);
+    });
+
+    it('should handle missing attributes', function () {
+        var viewModel = Bahmni.Appointments.AppointmentServiceViewModel.createFromResponse(serviceResponse);
+
+        expect(viewModel.attributes).toBeDefined();
+        expect(viewModel.attributes).toEqual([]);
+    });
 });

--- a/test/models/appointmentService.spec.js
+++ b/test/models/appointmentService.spec.js
@@ -127,4 +127,53 @@ describe('AppointmentService', function () {
          {dayOfWeek: 'TUESDAY', uuid: undefined, voided: false, maxAppointmentsLimit: 2, startTime: startTime2, endTime: endTime2},
          {dayOfWeek: 'SATURDAY', uuid: 'uuid1', voided: true, maxAppointmentsLimit: 2, startTime: startTime2, endTime: endTime2}]);
     });
+
+    it('should include attributes when creating from UI object', function () {
+        var service = {
+            name: 'Chemotherapy',
+            description: 'For cancer',
+            attributes: [
+                {
+                    attributeTypeUuid: 'attr-type-uuid-1',
+                    value: 'test value',
+                    voided: false
+                },
+                {
+                    uuid: 'existing-attr-uuid',
+                    attributeTypeUuid: 'attr-type-uuid-2',
+                    value: '123',
+                    voided: false
+                }
+            ]
+        };
+        var appointmentService = Bahmni.Appointments.AppointmentService.createFromUIObject(service);
+
+        expect(appointmentService.attributes).toBeDefined();
+        expect(appointmentService.attributes.length).toBe(2);
+        expect(appointmentService.attributes[0].attributeTypeUuid).toBe('attr-type-uuid-1');
+        expect(appointmentService.attributes[0].value).toBe('test value');
+        expect(appointmentService.attributes[1].uuid).toBe('existing-attr-uuid');
+    });
+
+    it('should handle empty attributes array', function () {
+        var service = {
+            name: 'Chemotherapy',
+            description: 'For cancer',
+            attributes: []
+        };
+        var appointmentService = Bahmni.Appointments.AppointmentService.createFromUIObject(service);
+
+        expect(appointmentService.attributes).toBeDefined();
+        expect(appointmentService.attributes.length).toBe(0);
+    });
+
+    it('should handle undefined attributes', function () {
+        var service = {
+            name: 'Chemotherapy',
+            description: 'For cancer'
+        };
+        var appointmentService = Bahmni.Appointments.AppointmentService.createFromUIObject(service);
+
+        expect(appointmentService.attributes).toEqual([]);
+    });
 });

--- a/test/services/appointmentsServiceService.spec.js
+++ b/test/services/appointmentsServiceService.spec.js
@@ -1,64 +1,113 @@
-'use strict';
+"use strict";
 
-describe('AppointmentsServiceService', function () {
-    var appointmentsServiceService, mockHttp;
-    mockHttp = jasmine.createSpyObj('$http', ['get', 'post', 'delete']);
-    mockHttp.get.and.callFake(function (params) {
-        return specUtil.respondWith({data: {}});
-    });
-    mockHttp.post.and.callFake(function (params) {
-        return specUtil.respondWith({data: {}});
-    });
+describe("AppointmentsServiceService", function () {
+  var appointmentsServiceService, mockHttp;
+  mockHttp = jasmine.createSpyObj("$http", ["get", "post", "delete"]);
+  mockHttp.get.and.callFake(function (params) {
+    return specUtil.respondWith({ data: {} });
+  });
+  mockHttp.post.and.callFake(function (params) {
+    return specUtil.respondWith({ data: {} });
+  });
 
-    beforeEach(function () {
-        module('bahmni.appointments');
-        module(function ($provide) {
-            $provide.value('$http', mockHttp);
-        });
-        inject(['appointmentsServiceService', function (_appointmentsServiceService_) {
-            appointmentsServiceService = _appointmentsServiceService_;
-        }]);
+  beforeEach(function () {
+    module("bahmni.appointments");
+    module(function ($provide) {
+      $provide.value("$http", mockHttp);
     });
+    inject([
+      "appointmentsServiceService",
+      function (_appointmentsServiceService_) {
+        appointmentsServiceService = _appointmentsServiceService_;
+      },
+    ]);
+  });
 
-    it('should post service data on save', function () {
-        appointmentsServiceService.save();
-        expect(mockHttp.post).toHaveBeenCalled();
-    });
+  it("should post service data on save", function () {
+    appointmentsServiceService.save();
+    expect(mockHttp.post).toHaveBeenCalled();
+  });
 
-    it('should get service load', function () {
-        var serviceUuid = "serviceUuid";
-        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
-        var params = {params: {uuid: serviceUuid, startDateTime: "startTime", endDateTime: "endTime"}, withCredentials: true, headers: headers};
-        appointmentsServiceService.getServiceLoad(serviceUuid, "startTime", "endTime");
-        expect(mockHttp.get).toHaveBeenCalledWith(Bahmni.Appointments.Constants.getServiceLoad, params);
-    });
+  it("should get service load", function () {
+    var serviceUuid = "serviceUuid";
+    var headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    var params = {
+      params: {
+        uuid: serviceUuid,
+        startDateTime: "startTime",
+        endDateTime: "endTime",
+      },
+      withCredentials: true,
+      headers: headers,
+    };
+    appointmentsServiceService.getServiceLoad(
+      serviceUuid,
+      "startTime",
+      "endTime",
+    );
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      Bahmni.Appointments.Constants.getServiceLoad,
+      params,
+    );
+  });
 
-    it('should delete the appointment service', function () {
-        var serviceUuid = "serviceUuid";
-        appointmentsServiceService.deleteAppointmentService(serviceUuid);
-        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
-        var params = {params: {uuid: serviceUuid}, withCredentials: true, headers: headers};
-        expect(mockHttp.delete).toHaveBeenCalledWith('/openmrs/ws/rest/v1/appointmentService', params);
-    });
+  it("should delete the appointment service", function () {
+    var serviceUuid = "serviceUuid";
+    appointmentsServiceService.deleteAppointmentService(serviceUuid);
+    var headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    var params = {
+      params: { uuid: serviceUuid },
+      withCredentials: true,
+      headers: headers,
+    };
+    expect(mockHttp.delete).toHaveBeenCalledWith(
+      "/openmrs/ws/rest/v1/appointmentService",
+      params,
+    );
+  });
 
-    it("should get appointment services with speciality and service types", function () {
-       appointmentsServiceService.getAllServicesWithServiceTypes();
-        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
-        var params = { withCredentials: true, headers: headers};
-        expect(mockHttp.get).toHaveBeenCalledWith('/openmrs/ws/rest/v1/appointmentService/all/full', params);
-    });
+  it("should get appointment services with speciality and service types", function () {
+    appointmentsServiceService.getAllServicesWithServiceTypes();
+    var headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    var params = { withCredentials: true, headers: headers };
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      "/openmrs/ws/rest/v1/appointmentService/all/full",
+      params,
+    );
+  });
 
-    it("should get all appointment services with default response", function () {
-        appointmentsServiceService.getAllServices();
-        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
-        var params = { withCredentials: true, headers: headers};
-        expect(mockHttp.get).toHaveBeenCalledWith('/openmrs/ws/rest/v1/appointmentService/all/default', params);
-    });
+  it("should get all appointment services with default response", function () {
+    appointmentsServiceService.getAllServices();
+    var headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    var params = { withCredentials: true, headers: headers };
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      "/openmrs/ws/rest/v1/appointmentService/all/default",
+      params,
+    );
+  });
 
-    it("should get all appointment service attribute types", function () {
-        appointmentsServiceService.getAllAttributeTypes();
-        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
-        var params = { withCredentials: true, headers: headers};
-        expect(mockHttp.get).toHaveBeenCalledWith(Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl, params);
-    });
+  it("should get all appointment service attribute types", function () {
+    appointmentsServiceService.getAllNonVoidedAttributeTypes();
+    var headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    var params = { withCredentials: true, headers: headers };
+    expect(mockHttp.get).toHaveBeenCalledWith(
+      Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl,
+      params,
+    );
+  });
 });

--- a/test/services/appointmentsServiceService.spec.js
+++ b/test/services/appointmentsServiceService.spec.js
@@ -54,4 +54,11 @@ describe('AppointmentsServiceService', function () {
         var params = { withCredentials: true, headers: headers};
         expect(mockHttp.get).toHaveBeenCalledWith('/openmrs/ws/rest/v1/appointmentService/all/default', params);
     });
+
+    it("should get all appointment service attribute types", function () {
+        appointmentsServiceService.getAllAttributeTypes();
+        var headers = {Accept: 'application/json', 'Content-Type': 'application/json'};
+        var params = { withCredentials: true, headers: headers};
+        expect(mockHttp.get).toHaveBeenCalledWith(Bahmni.Appointments.Constants.appointmentServiceAttributeTypesUrl, params);
+    });
 });


### PR DESCRIPTION
JIRA -> [BAH-4229](https://bahmni.atlassian.net/browse/BAH-4229)

 Implements frontend support for the appointment service attributes feature that was recently added to the backend. This allows administrators to define and manage custom attributes for appointment services with configurable datatypes and validation rules.

## Changes

  - API Integration: Added endpoint configuration and service method to fetch attribute types from `/openmrs/ws/rest/v1/appointment-service-attribute-types`
  - Data Models: Updated `AppointmentService` and `AppointmentServiceViewModel` to support attributes with proper parsing and filtering of voided attributes
  - UI Component: Created `serviceAttributes` directive that dynamically renders input fields based on attribute datatypes (text, number, date, boolean)
  - Validation: Implemented cardinality validation in the controller to enforce minOccurs/maxOccurs constraints before saving
  - Access Control: Added privilege-based field disabling using `app:appointments:manageServices` privilege
  
  
<img width="1728" height="992" alt="Screenshot 2025-10-27 at 9 15 13 AM" src="https://github.com/user-attachments/assets/7640de96-ad3a-47a9-b885-1c6d5a76d1f1" />