### PR TITLE
BAH-4708: Bump base image to httpd:2.4.67-alpine3.23 to fix critical CVEs

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM httpd:2.4.62-alpine3.20
+FROM httpd:2.4.67-alpine3.23
 COPY dist/. /usr/local/apache2/htdocs/appointments/


### PR DESCRIPTION
**JIRA**: [BAH-4708](https://bahmni.atlassian.net/browse/BAH-4708)

## What Changed
- `package/docker/Dockerfile`: `FROM httpd:2.4.62-alpine3.20` → `FROM httpd:2.4.67-alpine3.23`

## Why
Trivy scan (Bahmni/security-reports @ ca55dc0, 2026-05-14) reported **5 CRITICAL** CVEs against `bahmni/appointments`, all rooted in Alpine 3.20 system packages shipped with `httpd:2.4.62-alpine3.20`:

| Package | Old Version | Fixed Version | CVEs |
|---|---|---|---|
| libcrypto3 | 3.3.2-r1 | 3.3.7-r0 | CVE-2025-15467, CVE-2026-31789 |
| libssl3 | 3.3.2-r1 | 3.3.7-r0 | CVE-2025-15467, CVE-2026-31789 |
| libxml2 | 2.12.7-r0 | 2.12.7-r1 | CVE-2024-56171 |

`httpd:2.4.67-alpine3.23` is built on Alpine 3.23 which ships the fixed package versions — all 5 CRITICAL findings are resolved by this base-image bump. No application code or build logic changes.

## How Tested
- [x] Tag existence and publish date verified against Docker Hub registry API (`httpd:2.4.67-alpine3.23`, published 2026-05-05)
- [ ] CI `Build & Publish Docker Image & Helm Chart` job green on this PR
- [ ] Post-merge: Trivy re-scan in `Bahmni/security-reports` shows 0 CRITICAL for `bahmni/appointments`
- [x] No unit/e2e test changes (Dockerfile-only change; no test coverage exists for the base image)

## Acceptance Criteria Met
- [x] All 5 CRITICAL CVEs addressed via base-image bump
- [x] Scope limited to `package/docker/Dockerfile`
- [x] No application or build logic changes

> **Note**: HIGH-severity findings (27) are tracked separately under [BAH-4709](https://bahmni.atlassian.net/browse/BAH-4709) (Part 2). Many are expected to drop as a side-effect of the Alpine 3.20 → 3.23 transition.

[BAH-4708]: https://bahmni.atlassian.net/browse/BAH-4708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BAH-4709]: https://bahmni.atlassian.net/browse/BAH-4709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ