### PR TITLE
BAH-4733 Changes to point new clinical page

### DIFF
--- a/config/ng-config.json
+++ b/config/ng-config.json
@@ -83,7 +83,7 @@
       "loginPageUrl": "../../bahmni/home/index.html#/login",
       "patientsURL": "/bahmni/clinical/index.html#/default/patient/",
       "patientsURLGeneralInformationTab": "/dashboard?currentTab=DASHBOARD_TAB_GENERAL_KEY",
-      "appointmentsListPatientLink": "/bahmni/clinical/index.html#/default/patient/{{patientId}}/dashboard?currentTab=DASHBOARD_TAB_GENERAL_KEY"
+      "appointmentsListPatientLink": "/bahmni/clinical/{{patientId}}"
     }
   },
   "Appointments": {


### PR DESCRIPTION
# BAH-4733 Summary

Migrated the React frontend from `/bahmni-new/` to `/bahmni/`, while moving legacy Angular modules under `/bahmni/v1/`.


## New Privilege Model

Added privilege-based access for legacy Angular UX:

* `app:legacy-registration`

  * Shows “Registration (Legacy)” tile
* `app:clinical:legacyPatientTabs`

  * Shows “Active (Legacy)” and “All (Legacy)” tabs

Users without these privileges see only the new React experience.

## Major Technical Updates

* Updated proxy routing to serve React and Angular apps separately
* Converted many relative Angular URLs to absolute `/bahmni/...` paths
* Added `/bahmni/v1/...` routing for legacy modules
* React assets moved under `/bahmni/static/`
* Added session/auth guard (`SessionGate`) for React apps
* Added redirects from old Angular clinical URLs to new React URLs
* Updated login/change-password paths to legacy Angular home
* Added proxy caching support

## Repository Updates

Changes were made across 7 repositories:

1. Bahmni `bahmni-proxy`
2. `bahmni-apps-frontend`
3. `openmrs-module-bahmniapps`
4. `standard-config`
5. `openmrs-module-appointments-frontend`
6. `clinic-config`
7. `bahmni-docker`

## Outcome

* React becomes the primary frontend under `/bahmni/`
* Angular legacy modules remain accessible under `/bahmni/v1/`
* Smooth coexistence between new React UX and legacy Angular UX
* Legacy access is controlled using privileges
